### PR TITLE
docs: sync 03-plan with current implementation

### DIFF
--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -191,6 +191,9 @@ Plan:
 
 - Plugin-managed **long-lived MCP process**: implemented for the localhost MCP HTTP service (avoid spawn-per-search latency; restart on crash; stop on unload)
 - Indexer **single-writer lock**: partial (plugin serializes its own runs; cross-process lock TBD)
+  - Clarification: “cross-process” means separate Node processes (e.g. Obsidian plugin indexing + a terminal-run `ailss-indexer`), not the plugin’s local MCP (stdio) setting.
+  - Goal: prevent concurrent writes to `<vault>/.ailss/index.sqlite` and avoid duplicate embedding calls/costs when two indexers run at the same time.
+  - Minimal approach: lockfile under `<vault>/.ailss/` with a clear “indexing already running” error and a safe TTL/force-unlock story.
 - DB **identity + validation**: implemented for embedding model/dimension (schema version later)
 
 ## 9) Production readiness (public distribution)

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -55,9 +55,23 @@ It also records a few **hard decisions** so code and docs stay consistent.
 ## 4) Obsidian plugin MVP (UI)
 
 - Semantic search modal UI (opens the selected note)
-- Keep “Apply” disabled at first, or limit it to calling existing scripts
+- No “Apply” UI for note edits yet; vault writes happen via gated MCP write tools (`apply=true`).
 
 ## 5) Obsidian-managed indexing (background)
+
+Status (current): partially implemented
+
+Implemented:
+
+- Manual “Reindex vault” command + optional debounced auto-index on file changes
+- Indexing status surface (status bar + modal)
+- Default ignore rules for vault-internal folders (e.g. `.obsidian`, `.trash`, `.ailss`)
+
+Remaining / TODO:
+
+- User-configurable exclusions + “blocked paths” events
+- Pause/resume UX (if needed)
+- Throttling/rate limiting (beyond batch size) for large vaults
 
 Goal:
 
@@ -131,7 +145,7 @@ Planned:
 TODO (to expand structured queries):
 
 - Add a generic frontmatter key/value index (e.g. `note_frontmatter_kv`) and an MCP tool to filter by arbitrary keys (e.g. `created`, `updated`).
-- Add date/range filters for `created` / `updated` (requires consistent formatting across the vault).
+- Date/range filters for `created` / `updated`: implemented via `search_notes` (`created_from`/`created_to`, `updated_from`/`updated_to`); requires consistent formatting across the vault.
 
 Write tools (explicit apply):
 
@@ -160,10 +174,14 @@ Safety contract (for all MCP tools that touch the vault):
 
 ## 7) Integration / operations
 
-- Local config (API key, vault path)
-- Privacy documentation + opt-in options
+Status (current): partially implemented
+
+- Local config (API key, vault path): implemented (plugin settings + env vars for CLI)
+- Privacy documentation + opt-in options: TODO
 
 ## 8) Production readiness (personal daily use)
+
+Status (current): partially implemented
 
 Goal:
 
@@ -171,9 +189,9 @@ Goal:
 
 Plan:
 
-- Plugin-managed **long-lived MCP process** (avoid spawn-per-search latency; restart on crash; stop on unload)
-- Indexer **single-writer lock** (prevent concurrent indexing from plugin/CLI)
-- DB **identity + validation** (embedding model/dimension now; schema version later)
+- Plugin-managed **long-lived MCP process**: implemented for the localhost MCP HTTP service (avoid spawn-per-search latency; restart on crash; stop on unload)
+- Indexer **single-writer lock**: partial (plugin serializes its own runs; cross-process lock TBD)
+- DB **identity + validation**: implemented for embedding model/dimension (schema version later)
 
 ## 9) Production readiness (public distribution)
 

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -230,6 +230,7 @@ Phase 0 — docs + contracts (no code changes)
 
 Phase 1 — add HTTP transport for the MCP server
 
+- Status: implemented
 - Add a new MCP entrypoint (in `packages/mcp`) that serves the same tools over streamable HTTP.
 - Use the MCP SDK server transport for streamable HTTP (SSE + POST).
 - Add minimal auth middleware (reject missing/invalid token).
@@ -237,6 +238,7 @@ Phase 1 — add HTTP transport for the MCP server
 
 Phase 2 — Obsidian plugin “AILSS service” lifecycle
 
+- Status: implemented
 - Add plugin settings:
   - enable/disable local service
   - port (default e.g. 31415) + bind address (fixed to 127.0.0.1)
@@ -250,6 +252,7 @@ Phase 2 — Obsidian plugin “AILSS service” lifecycle
 
 Phase 3 — Codex-triggered writes over MCP (no per-edit UI)
 
+- Status: implemented
 - Expose explicit write tools over the localhost MCP server when enabled:
   - `edit_note` (apply line-based patch ops; default apply=false)
   - `capture_note` (create new note in `<vault>/100. Inbox/` by default)
@@ -259,6 +262,7 @@ Phase 3 — Codex-triggered writes over MCP (no per-edit UI)
 
 Phase 4 — Codex setup UX
 
+- Status: implemented
 - Provide a plugin UI that outputs a ready-to-paste `~/.codex/config.toml` block.
 - Troubleshooting: if MCP fails, check service running + token + port.
 


### PR DESCRIPTION
## What

- Update `docs/03-plan.md` to match the current implementation (MCP tool surface, HTTP multi-session, Obsidian MCP service UX).
- Mark Codex integration phases 1–4 as implemented.
- Clarify background indexing status.

## Why

- `docs/03-plan.md` had drift vs code (outdated tool lists / stale references / unclear “done vs next”), which made it easy to misread project status.
- Keeping the plan accurate reduces rework and makes future doc updates and onboarding easier.

## How

- Doc-only change (no code/behavior changes).