### PR TITLE
feat: auto-apply workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ AILSS works best when your assistant is explicitly steered to:
 - use MCP tools (retrieval-first, DB-backed reads)
 - follow the vault frontmatter + typed-link rules
 - keep writes gated (`apply=true`) and auditable
+- follow a predictable write workflow (preview with `apply=false`, then apply with `apply=true` for common note edits)
 
 ### Vault prompt files (Obsidian)
 

--- a/docs/ops/agents-snippet.md
+++ b/docs/ops/agents-snippet.md
@@ -29,7 +29,7 @@ When the `ailss` MCP server is available:
    - For new notes, prefer `capture_note` so required frontmatter keys exist and `id` matches `created`.
      - When capturing, set non-default frontmatter via `frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
      - Prefer reusing existing `tags`/`keywords` by checking `list_tags` / `list_keywords` first (avoid near-duplicates).
-     - Write the note body to be readable later (not raw chat logs): keep it short and structured (Context / Key points / Next actions / Open questions / References).
+     - Write the note body to be readable later
    - Default policy for `capture_note` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
      - Only pause when the user explicitly requests “preview only” or the preview indicates a suspicious target.
    - Do not override identity fields (`id`, `created`) unless the user explicitly asks.

--- a/docs/ops/agents-snippet.md
+++ b/docs/ops/agents-snippet.md
@@ -30,7 +30,8 @@ When the `ailss` MCP server is available:
      - When capturing, set non-default frontmatter via `frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
      - Prefer reusing existing `tags`/`keywords` by checking `list_tags` / `list_keywords` first (avoid near-duplicates).
      - Write the note body to be readable later (not raw chat logs): keep it short and structured (Context / Key points / Next actions / Open questions / References).
-   - For note creation, do `apply=false` → confirm with the user → `apply=true`.
+   - Default policy for `capture_note` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
+     - Only pause when the user explicitly requests “preview only” or the preview indicates a suspicious target.
    - Do not override identity fields (`id`, `created`) unless the user explicitly asks.
    - Timestamps:
      - `capture_note` generates `id`/`created`/`updated` using system local time (no fixed timezone) and stores them as ISO to seconds without a timezone suffix (`YYYY-MM-DDTHH:mm:ss`).

--- a/docs/ops/agents-snippet.md
+++ b/docs/ops/agents-snippet.md
@@ -29,6 +29,7 @@ When the `ailss` MCP server is available:
    - For new notes, prefer `capture_note` so required frontmatter keys exist and `id` matches `created`.
      - When capturing, set non-default frontmatter via `frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
      - Prefer reusing existing `tags`/`keywords` by checking `list_tags` / `list_keywords` first (avoid near-duplicates).
+     - Write the note body to be readable later (not raw chat logs): keep it short and structured (Context / Key points / Next actions / Open questions / References).
    - For note creation, do `apply=false` → confirm with the user → `apply=true`.
    - Do not override identity fields (`id`, `created`) unless the user explicitly asks.
    - Timestamps:

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -66,11 +66,6 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 1. Run `get_context` with the intended topic/title to avoid duplicates and reuse existing naming.
 2. Draft a new note (title + frontmatter overrides that match the content).
    - Prefer reusing existing tags/keywords: call `list_tags` / `list_keywords` first.
-   - Write the body for future reading/maintenance (not raw chat):
-     - short `summary`
-     - key points (bullets)
-     - next actions + open questions
-     - references (either `source: []` or `cites` typed links)
 3. Call `capture_note` with `apply=false` to preview the resulting path + sha256.
 4. Confirm with the user.
 5. Call `capture_note` again with `apply=true`.

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -65,6 +65,11 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 1. Run `get_context` with the intended topic/title to avoid duplicates and reuse existing naming.
 2. Draft a new note (title + frontmatter overrides that match the content).
    - Prefer reusing existing tags/keywords: call `list_tags` / `list_keywords` first.
+   - Write the body for future reading/maintenance (not raw chat):
+     - short `summary`
+     - key points (bullets)
+     - next actions + open questions
+     - references (either `source: []` or `cites` typed links)
 3. Call `capture_note` with `apply=false` to preview the resulting path + sha256.
 4. Confirm with the user.
 5. Call `capture_note` again with `apply=true`.

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -54,7 +54,8 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 
 ## Safe writes (when enabled)
 
-- Prefer `apply=false` first (dry-run), then confirm with the user, then `apply=true`.
+- Default policy for `capture_note` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
+  - Only pause when the user explicitly requests “preview only” or the preview indicates a suspicious target.
 - For edits, use `expected_sha256` to avoid overwriting concurrent changes.
 - Keep identity fields safe: do not override `id`/`created` unless the user explicitly requests it.
 

--- a/docs/standards/vault/README.md
+++ b/docs/standards/vault/README.md
@@ -9,7 +9,8 @@ The rules are split into topic-scoped docs so they stay navigable and can be ref
 - Assistant workflow (how an LLM should operate + MCP usage): `./assistant-workflow.md`
 - Frontmatter schema (identity fields, entity/layer/status, templates): `./frontmatter-schema.md`
 - Typed links (frontmatter relations as graph edges): `./typed-links.md`
-- Vault structure (folders, naming, Obsidian grammar, wikilinks): `./vault-structure.md`
+- Vault structure (folders, naming, wikilinks): `./vault-structure.md`
+- Note style (optional Markdown/language conventions): `./note-style.md`
 
 ## Prompt installer
 

--- a/docs/standards/vault/README.md
+++ b/docs/standards/vault/README.md
@@ -14,4 +14,10 @@ The rules are split into topic-scoped docs so they stay navigable and can be ref
 
 ## Prompt installer
 
-The Obsidian plugin “Prompt installer (vault root)” stitches these docs into a single prompt file (for example `AGENTS.md`) and writes it to the vault root.
+The Obsidian plugin “Prompt installer (vault root)” stitches these docs into a single prompt file (for example `AGENTS.md`) and writes it to the vault root:
+
+- `assistant-workflow.md`
+- `frontmatter-schema.md`
+- `typed-links.md`
+- `vault-structure.md`
+- `note-style.md`

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -24,7 +24,8 @@ Global working rules for the AILSS Obsidian vault.
 
 - Required: before summarizing/classifying/reviewing/link-checking, query AILSS MCP for vault metadata.
 - Principles:
-  - Use read-first by default. Writes require explicit approval (use `apply=true` only after preview).
+  - Use read-first by default. Writes require explicit `apply=true`.
+    - Default policy: do `apply=false` preview first, then proceed with `apply=true` automatically for `capture_note` / `edit_note` / `improve_frontmatter` (auto-apply).
   - Leading queries: `get_context` (semantic retrieval), `get_vault_tree` (folder/file structure)
   - Follow-up queries: `read_note` (exact text + frontmatter), `get_typed_links` (typed-link graph)
 - Recommended flow:
@@ -34,8 +35,8 @@ Global working rules for the AILSS Obsidian vault.
      - If you only know `id`/`title`, use `resolve_note` (preferred) or `search_notes` to find candidate paths first, then `read_note`.
   3. Use `get_typed_links` (outgoing only) to check for missing relationships and navigation gaps.
   4. Use the typed-links coverage checklist (see `./typed-links.md`) to fill obvious omissions.
-  5. Optional: use `suggest_typed_links` to propose candidates, then apply via `edit_note` (requires `apply=true` approval).
-  6. Use `edit_note` for edits and `relocate_note` for moves/renames (both require `apply=true` approval).
+  5. Optional: use `suggest_typed_links` to propose candidates, then apply via `edit_note` (`apply=false` preview → `apply=true` auto-apply).
+  6. Use `edit_note` for edits and `relocate_note` for moves/renames (`relocate_note` is still manual confirm; `edit_note` is auto-apply).
 - Failure handling: record the error and cause; temporarily fall back to `rg`/`find` only if MCP calls fail.
 
 ### Tool summary
@@ -52,10 +53,10 @@ Global working rules for the AILSS Obsidian vault.
 - `frontmatter_validate`: validates vault-wide frontmatter key presence + `id`/`created` consistency.
 - `find_broken_links`: detects unresolved wikilinks/typed links by resolving targets against indexed notes.
 - `suggest_typed_links`: suggests typed-link candidates using already-indexed body wikilinks (DB-backed).
-- `capture_note`: creates a new note (requires `apply=true` approval).
-- `edit_note`: applies line-based patch ops to a note (requires `apply=true` approval).
-- `improve_frontmatter`: normalizes/adds required frontmatter keys for a note (requires `apply=true` approval).
-- `relocate_note`: moves/renames a note (requires `apply=true` approval).
+- `capture_note`: creates a new note (`apply=false` preview → `apply=true` auto-apply by default).
+- `edit_note`: applies line-based patch ops to a note (`apply=false` preview → `apply=true` auto-apply by default).
+- `improve_frontmatter`: normalizes/adds required frontmatter keys for a note (`apply=false` preview → `apply=true` auto-apply by default).
+- `relocate_note`: moves/renames a note (manual confirm; requires `apply=true`).
 
 ### Semantic retrieval guidance
 

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -75,8 +75,7 @@ Global working rules for the AILSS Obsidian vault.
 - New notes: when capturing, set non-default frontmatter via `capture_note.frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
 - Capture quality: write captured notes to be readable and maintainable later (not raw chat logs).
   - Title: specific and stable; add disambiguators when needed (Korean + English in parentheses is OK).
-  - Summary: 2–5 sentences that answer “what is this note for?” + “what’s the next action?”
-  - Body: keep a short structure such as “Context / Key points / Next actions / Open questions / References”.
+  - Summary: 2–5 sentences that answer “what is this note for?”
 - Tags/keywords: before adding a new value, check existing vocabulary via `list_tags` / `list_keywords` and reuse when possible.
 - Typed links: review the coverage checklist items (`instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `same_as`, `supersedes`).
 - Coverage log: keep semantic retrieval + literal checks together (what `get_context` returned, and what `read_note` confirmed).

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -82,7 +82,6 @@ Global working rules for the AILSS Obsidian vault.
 - Coverage log: keep semantic retrieval + literal checks together (what `get_context` returned, and what `read_note` confirmed).
 - Links: run `find_broken_links` (preferred) and fix unresolved targets; fall back to `rg "\\[\\[" -n` if needed.
 - Assets: ensure a note-adjacent `assets/` folder exists; avoid absolute/external file paths.
-- Structure: keep H1 equal to filename; use H2–H4 for most content.
 - MCP: keep a log of MCP calls before summarizing/classifying/reviewing.
 - After: record changed file paths and entity/layer changes.
 - Rationale: confirm rationale was explained in chat (not inserted into note bodies).

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -72,6 +72,10 @@ Global working rules for the AILSS Obsidian vault.
 - Before: gather related notes/assets (`get_context`, `rg "assets/" -n`).
 - Frontmatter: verify required key presence (`id`, `created`, `title`, `summary`, `aliases`, `entity`, `layer`, `tags`, `keywords`, `status`, `updated`, `source`).
 - New notes: when capturing, set non-default frontmatter via `capture_note.frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
+- Capture quality: write captured notes to be readable and maintainable later (not raw chat logs).
+  - Title: specific and stable; add disambiguators when needed (Korean + English in parentheses is OK).
+  - Summary: 2–5 sentences that answer “what is this note for?” + “what’s the next action?”
+  - Body: keep a short structure such as “Context / Key points / Next actions / Open questions / References”.
 - Tags/keywords: before adding a new value, check existing vocabulary via `list_tags` / `list_keywords` and reuse when possible.
 - Typed links: review the coverage checklist items (`instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `same_as`, `supersedes`).
 - Coverage log: keep semantic retrieval + literal checks together (what `get_context` returned, and what `read_note` confirmed).

--- a/docs/standards/vault/note-style.md
+++ b/docs/standards/vault/note-style.md
@@ -1,0 +1,22 @@
+# Note style (optional)
+
+This document contains **optional** Markdown and writing-style conventions for vault notes.
+
+AILSS does not require these conventions for indexing, and the Obsidian plugin prompt installer does **not** bundle this file into `AGENTS.md` by default.
+
+## Obsidian Markdown conventions (optional)
+
+- Headings: use ATX `#` style only. Use H1 once; H2–H4 for most structure.
+- Lists: standardize on `-` bullets; indent sub-lists with 2 spaces.
+- Code: use triple backticks code fences and specify the language when possible.
+- Tables: use pipe (`|`) tables and include a header row.
+- Emphasis: use `**bold**` and `*italic*` sparingly (meaning-first).
+- Callouts: use Obsidian defaults only (`[!NOTE]`, `[!TIP]`, `[!WARNING]`).
+
+## Language and typography (optional)
+
+- Vault notes are written in Korean using the “~해요” style.
+- For technical terms, use Korean + English on first mention (example: frontmatter (metadata)).
+- Record date/time in ISO-8601 format (example: `YYYY-MM-DDTHH:mm:ss`).
+- Code comments should be short, in Korean, and written as noun phrases (no sentence endings).
+- Avoid the middle dot (·) in title/body/lists/tables; prefer commas, hyphens, en dashes (–), semicolons, or conjunctions.

--- a/docs/standards/vault/note-style.md
+++ b/docs/standards/vault/note-style.md
@@ -2,7 +2,9 @@
 
 This document contains **optional** Markdown and writing-style conventions for vault notes.
 
-AILSS does not require these conventions for indexing, and the Obsidian plugin prompt installer does **not** bundle this file into `AGENTS.md` by default.
+AILSS does not require these conventions for indexing. The Obsidian plugin prompt installer bundles this file into installed prompts so assistants can follow a consistent style when desired.
+
+Do not rewrite existing notes solely to enforce style unless the user explicitly asks.
 
 ## Obsidian Markdown conventions (optional)
 

--- a/docs/standards/vault/vault-structure.md
+++ b/docs/standards/vault/vault-structure.md
@@ -11,11 +11,14 @@
 - For notes under `10. Projects/10. HouMe/OLD/`, standardize first as `entity: document`, `layer: physical`, then reclassify later if needed.
 - For each unit of work, check broken wikilinks via `rg "\\[\\[" -n`, and move assets into a note-adjacent `assets/` folder.
 
-This document summarizes the AILSS ontology, layers, and Obsidian conventions (and how they map into typed links and frontmatter).
+This document summarizes the AILSS vault structure, naming, and linking conventions (and how they map into typed links and frontmatter).
 
 ## Naming and asset placement
 
 - Filenames should use a Korean title with optional English in parentheses (example: `도메인 주도 설계(Domain-Driven Design).md`).
+- Filenames (cross-device safe): avoid characters/sequences that can break links or Sync on other OSes.
+  - Avoid: `\\` `/` `:` `*` `?` `"` `<` `>` `|` `#` `^` and `%%` / `[[` / `]]`.
+  - Prefer using only letters/numbers/spaces plus `-` and `_` when in doubt.
 - Keep assets in a note-adjacent `assets/` folder and embed via relative paths (example: `20. Areas/50. AILSS/assets/diagram.png`).
 - After moving a path/file, check for broken links via `rg "\\[\\[" -n`.
 
@@ -46,21 +49,6 @@ This document summarizes the AILSS ontology, layers, and Obsidian conventions (a
 - Shared principles/definitions/patterns → promote to `20. Areas` or `30. Resources` and classify as `entity: concept|definition|pattern`.
 - After moving files, immediately check for broken links via `rg "\\[\\[" -n`.
 
-## Obsidian grammar rules
-
-- Headings: use ATX `#` style only. Use H1 once; H2–H4 for most structure.
-- Lists: standardize on `-` bullets; indent sub-lists with 2 spaces.
-- Code: use triple backticks code fences and specify the language when possible.
-- Tables: use pipe (`|`) tables and include a header row.
-- Emphasis: use `**bold**` and `*italic*` sparingly (meaning-first).
-- Callouts: use Obsidian defaults only (`[!NOTE]`, `[!TIP]`, `[!WARNING]`).
-- Embeds: use `![[filename]]`; keep assets in a note-adjacent `assets/` folder.
-- Tags: use a small number of navigation tags; promote semantic relations into typed links.
-- Filenames: keep the vault filename convention consistent (see naming rule above).
-- Filenames (cross-device safe): avoid characters/sequences that can break links or Sync on other OSes.
-  - Avoid: `\\` `/` `:` `*` `?` `"` `<` `>` `|` `#` `^` and `%%` / `[[` / `]]`.
-  - Prefer using only letters/numbers/spaces plus `-` and `_` when in doubt.
-
 ## Wikilinks, anchors, and footnotes
 
 - Wikilinks: use `[[Note title]]` by default; use `[[Note title|Display text]]` when display text should differ.
@@ -71,11 +59,3 @@ This document summarizes the AILSS ontology, layers, and Obsidian conventions (a
 - Block references: attach `^id` to the smallest quote-worthy block and reference via `[[Note#^id]]`.
 - Footnotes: use `[^key]` in the body and define at the bottom as `[^key]: ...` (use short meaningful keys).
 - Link checking: before/after work, check broken wikilinks via `rg "\\[\\[" -n`.
-
-## Language and typography rules
-
-- Vault notes are written in Korean using the “~해요” style.
-- For technical terms, use Korean + English on first mention (example: frontmatter (metadata)).
-- Record date/time in ISO-8601 format (example: `YYYY-MM-DDTHH:mm:ss`).
-- Code comments should be short, in Korean, and written as noun phrases (no sentence endings).
-- Do not use the middle dot (·) anywhere (title/body/lists/tables). If you need separators, use commas, hyphens, en dashes (–), semicolons, or conjunctions instead.

--- a/packages/mcp/src/tools/captureNote.ts
+++ b/packages/mcp/src/tools/captureNote.ts
@@ -90,12 +90,7 @@ export function registerCaptureNoteTool(server: McpServer, deps: McpToolDeps): v
       ].join(" "),
       inputSchema: {
         title: z.string().min(1).describe("Note title"),
-        body: z
-          .string()
-          .default("")
-          .describe(
-            "Note body (markdown). Recommended: short summary, key points, next actions/open questions.",
-          ),
+        body: z.string().default("").describe("Note body (markdown)."),
         folder: z
           .string()
           .default("100. Inbox")

--- a/packages/obsidian-plugin/src/utils/promptTemplates.ts
+++ b/packages/obsidian-plugin/src/utils/promptTemplates.ts
@@ -1,5 +1,6 @@
 import assistantWorkflow from "../../../../docs/standards/vault/assistant-workflow.md";
 import frontmatterSchema from "../../../../docs/standards/vault/frontmatter-schema.md";
+import noteStyle from "../../../../docs/standards/vault/note-style.md";
 import typedLinks from "../../../../docs/standards/vault/typed-links.md";
 import vaultStructure from "../../../../docs/standards/vault/vault-structure.md";
 
@@ -17,7 +18,7 @@ function normalizeMarkdown(text: string): string {
 }
 
 export function promptTemplate(_kind: PromptKind): string {
-	const parts = [assistantWorkflow, frontmatterSchema, typedLinks, vaultStructure]
+	const parts = [assistantWorkflow, frontmatterSchema, typedLinks, vaultStructure, noteStyle]
 		.map(normalizeMarkdown)
 		.map((part) => part.trim())
 		.filter(Boolean);


### PR DESCRIPTION
## What

- Document an “auto-apply” workflow for AILSS write tools: run a single `apply=false` preview, then immediately proceed with `apply=true` automatically for `capture_note`, `edit_note`, and `improve_frontmatter` (while keeping `relocate_note` manual-confirm by policy).
- Improve capture quality guidance so new notes are readable/maintainable later (better titles, 2–5 sentence summaries).
- Remove prescriptive body section template guidance (e.g., Context / Key points / …) and keep the guidance at the level of make the body readable later.
- Simplify the `capture_note` tool schema description for `body` so it no longer suggests a specific structure.
- Move Markdown/language style rules out of `vault-structure.md` into a dedicated `note-style.md`, and include it in the Obsidian Prompt installer bundle so installed prompts contain the full guidance set in one place.

## Why

- Reduce repeated “preview → user says apply → apply” friction while keeping the existing safety model (explicit `apply=true` still required for any actual write).
- Improve long-term maintainability of captured notes without enforcing a rigid body template.
- Keep vault structure/linking rules separate from optional style conventions, while still making the style guidance available to assistants via the installed prompt bundle.
- Support the project priority: stable desktop DB + MCP integration with safe/consistent write behavior.

## How

- Updated vault workflow and ops guidance to describe the auto-apply policy (`apply=false` preview once → auto `apply=true` for the three write tools; `relocate_note` remains manual).
- Updated capture quality guidance (title + summary) while removing the explicit body section template from docs/skill/snippet.
- Updated `capture_note` tool input schema description to avoid implying a specific body structure.
- Removed “Obsidian grammar rules” and “Language and typography rules” from `vault-structure.md`.
- Added `note-style.md` as the home for optional style conventions.
- Updated the Obsidian plugin prompt bundling to include `note-style.md` in installed prompts.