### PR TITLE
fix: increase default MCP HTTP max sessions to 10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,15 @@ This repo recommends Conventional Commits.
   - Example mapping: changes under `packages/obsidian-plugin/*` → scope `plugin` (not `obsidian-plugin`)
   - If a change spans multiple areas, **default to splitting into multiple commits** with the tightest valid scope per commit; use `monorepo` only for inherently cross-cutting changes (or when the user explicitly wants a single commit)
 
+### 2.8 Pull Request conventions (required)
+
+- Title format: `<type>: <title>`
+  - Allowed `type`: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`
+- Body: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
+- Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).
+- Testing: include the exact validation commands you ran (or explicitly state `Not run` and why).
+- Issues: fill `Fixes #...` when applicable; otherwise write `N/A`.
+
 ---
 
 ## 3. Agent working rules: accuracy / scope

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ This repo recommends Conventional Commits.
 - Title format: `<type>: <title>`
   - Allowed `type`: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`
 - Body: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
+- Language: PR title and body must be written in English.
 - Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).
 - Testing: include the exact validation commands you ran (or explicitly state `Not run` and why).
 - Issues: fill `Fixes #...` when applicable; otherwise write `N/A`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ This repo recommends Conventional Commits.
   - Allowed `type`: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`
 - Body: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
 - Language: PR title and body must be written in English.
+- Sections: for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).
 - Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).
 - Testing: include the exact validation commands you ran (or explicitly state `Not run` and why).
 - Issues: fill `Fixes #...` when applicable; otherwise write `N/A`.

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -303,7 +303,7 @@ Status (implemented):
 
 - Implemented in `packages/mcp/src/httpServer.ts` using a session manager that creates one server + transport per `initialize`.
 - Defaults:
-  - `AILSS_MCP_HTTP_MAX_SESSIONS=5`
+  - `AILSS_MCP_HTTP_MAX_SESSIONS=20`
   - `AILSS_MCP_HTTP_IDLE_TTL_MS=3600000` (1 hour)
 
 Why this needs explicit design:

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -303,7 +303,7 @@ Status (implemented):
 
 - Implemented in `packages/mcp/src/httpServer.ts` using a session manager that creates one server + transport per `initialize`.
 - Defaults:
-  - `AILSS_MCP_HTTP_MAX_SESSIONS=20`
+  - `AILSS_MCP_HTTP_MAX_SESSIONS=10`
   - `AILSS_MCP_HTTP_IDLE_TTL_MS=3600000` (1 hour)
 
 Why this needs explicit design:

--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -171,9 +171,9 @@ function getSingleHeaderValue(req: IncomingMessage, name: string): string | null
 }
 
 function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "5").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "20").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 5;
+  if (!Number.isFinite(n) || n < 1) return 20;
   return n;
 }
 

--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -171,9 +171,9 @@ function getSingleHeaderValue(req: IncomingMessage, name: string): string | null
 }
 
 function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "20").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "10").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 20;
+  if (!Number.isFinite(n) || n < 1) return 10;
   return n;
 }
 


### PR DESCRIPTION
## What

- Raise the default `AILSS_MCP_HTTP_MAX_SESSIONS` from 5 to 10 for the MCP HTTP server.
- Update the documented default in `docs/03-plan.md`.
- Document PR conventions in `AGENTS.md` (including “PRs must be written in English”).

## Why

- With 10+ parallel Codex sessions, the previous default max (5) can cause server-side session eviction.
- After eviction, subsequent tool calls from that client can fail with HTTP 404 (`Session not found`), surfacing as intermittent `... 404 Not Found ... /mcp` errors.
- Increasing the default to 10 reduces eviction frequency for the common “~10 parallel sessions” workflow while keeping resource growth bounded.

## How

- Update `packages/mcp/src/httpServer.ts` to default `AILSS_MCP_HTTP_MAX_SESSIONS` to `10` when not explicitly set.
- Update `docs/03-plan.md` to reflect the new default.
- Add PR-writing rules to `AGENTS.md` (title format, template usage, and English-only PR text).