### PR TITLE
feat: add MCP status modal

### DIFF
--- a/packages/obsidian-plugin/README.md
+++ b/packages/obsidian-plugin/README.md
@@ -66,5 +66,5 @@ When symlinked from the monorepo, you can usually leave MCP/indexer args empty a
 - `AILSS: Reindex vault`: runs the indexer to update `<Vault>/.ailss/index.sqlite`
 - `AILSS: Indexing status`: shows indexing progress + last successful indexing time
 
-The plugin also adds status bar items that show indexing progress (and last success time) and whether the MCP service is running.
+The plugin also adds status bar items that show indexing progress (and last success time) and the MCP service status (click for details + one-click restart).
 Times shown in the UI are displayed in your system timezone (local time).

--- a/packages/obsidian-plugin/src/ui/mcpStatusModal.ts
+++ b/packages/obsidian-plugin/src/ui/mcpStatusModal.ts
@@ -1,0 +1,120 @@
+import { ButtonComponent, Modal, Notice, Setting } from "obsidian";
+
+import type AilssObsidianPlugin from "../main.js";
+import type { AilssMcpHttpServiceStatusSnapshot } from "../main.js";
+import { formatAilssTimestampForUi } from "../utils/dateTime.js";
+
+export class AilssMcpStatusModal extends Modal {
+	private statusTextEl: HTMLElement | null = null;
+	private metaTextEl: HTMLElement | null = null;
+	private errorTextEl: HTMLElement | null = null;
+	private restartButton: ButtonComponent | null = null;
+	private restarting = false;
+
+	constructor(
+		app: AilssObsidianPlugin["app"],
+		private readonly plugin: AilssObsidianPlugin,
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("ailss-obsidian");
+
+		contentEl.createEl("h2", { text: "AILSS MCP status" });
+
+		this.statusTextEl = contentEl.createDiv({ cls: "ailss-status" });
+		this.metaTextEl = contentEl.createDiv({ cls: "ailss-status" });
+		this.errorTextEl = contentEl.createDiv({ cls: "ailss-modal-message" });
+
+		new Setting(contentEl).setName("Actions").addButton((button) => {
+			this.restartButton = button;
+			button.setButtonText("Restart service");
+			button.setCta();
+			button.onClick(() => void this.restartService());
+		});
+
+		this.refresh();
+	}
+
+	onClose(): void {
+		this.statusTextEl = null;
+		this.metaTextEl = null;
+		this.errorTextEl = null;
+		this.restartButton = null;
+		this.contentEl.empty();
+	}
+
+	private refresh(): void {
+		const snapshot = this.plugin.getMcpHttpServiceStatusSnapshot();
+		this.render(snapshot);
+	}
+
+	private render(snapshot: AilssMcpHttpServiceStatusSnapshot): void {
+		if (this.statusTextEl) {
+			this.statusTextEl.setText(statusLine(snapshot, { restarting: this.restarting }));
+		}
+
+		if (this.metaTextEl) {
+			const startedAt = formatAilssTimestampForUi(snapshot.startedAt);
+			const lastStoppedAt = formatAilssTimestampForUi(snapshot.lastStoppedAt);
+			const metaParts = [
+				`Service: ${snapshot.enabled ? "Enabled" : "Disabled"}`,
+				`URL: ${snapshot.url}`,
+				startedAt ? `Started: ${startedAt}` : "",
+				lastStoppedAt ? `Last stopped: ${lastStoppedAt}` : "",
+				snapshot.lastExitCode === null ? "" : `Last exit: ${snapshot.lastExitCode}`,
+				!snapshot.enabled ? "Enable the service in settings to start/restart it." : "",
+			];
+			this.metaTextEl.setText(metaParts.filter(Boolean).join("\n"));
+		}
+
+		if (this.errorTextEl) {
+			const message = snapshot.lastErrorMessage?.trim() ?? "";
+			if (message) {
+				this.errorTextEl.style.display = "";
+				this.errorTextEl.setText(message);
+			} else {
+				this.errorTextEl.style.display = "none";
+				this.errorTextEl.setText("");
+			}
+		}
+
+		if (this.restartButton) {
+			this.restartButton.setDisabled(this.restarting || !snapshot.enabled);
+		}
+	}
+
+	private async restartService(): Promise<void> {
+		if (this.restarting) return;
+
+		this.restarting = true;
+		this.refresh();
+		try {
+			await this.plugin.restartMcpHttpService();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			new Notice(`Restart failed: ${message}`);
+		} finally {
+			this.restarting = false;
+			this.refresh();
+		}
+	}
+}
+
+function statusLine(
+	snapshot: AilssMcpHttpServiceStatusSnapshot,
+	options: { restarting: boolean },
+): string {
+	if (options.restarting) return "Status: Restarting…";
+	if (!snapshot.enabled) return "Status: Off";
+	if (snapshot.running) return "Status: Running";
+	if (snapshot.lastErrorMessage) return "Status: Error";
+	if (snapshot.lastStoppedAt) {
+		const lastStoppedAt = formatAilssTimestampForUi(snapshot.lastStoppedAt);
+		return `Status: Stopped (last: ${lastStoppedAt ?? snapshot.lastStoppedAt})`;
+	}
+	return "Status: Stopped";
+}

--- a/packages/obsidian-plugin/styles.css
+++ b/packages/obsidian-plugin/styles.css
@@ -50,6 +50,10 @@ If your plugin does not need CSS, delete this file.
 	cursor: pointer;
 }
 
+.ailss-obsidian-mcp-statusbar {
+	cursor: pointer;
+}
+
 .ailss-obsidian-statusbar.is-running {
 	color: var(--text-accent);
 }


### PR DESCRIPTION
## What

- Add clickable MCP status bar item that opens an MCP status modal (Off/Running/Stopped/Error).
- Show the last MCP service error message when present.
- Add one-click actions: restart service + copy error message.
- Make MCP status bar item visually clickable (cursor pointer).
- Update plugin README to mention click-to-details.

## Why

- Improve in-Obsidian visibility into MCP service state and failures.
- Speed up recovery by restarting from the status UI (no settings navigation).
- Make it easy to share error text for debugging/support.

## How

- Expose a `getMcpHttpServiceStatusSnapshot()` helper on the plugin to keep UI logic read-only.
- Implement `AilssMcpStatusModal` UI.
- Wire status bar click to open the modal.
- Reuse existing `restartMcpHttpService()`; copy uses the Clipboard API.
