### PR TITLE
fix: simplify edit_note ops schema for MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Write tools are disabled by default and require `AILSS_ENABLE_WRITE_TOOLS=1`. Th
 - `edit_note`: applies line-based patch ops to an existing note.  
   Required: `path`, `ops` (insert/delete/replace).  
   Options: `expected_sha256`, `apply` (default false), `reindex_after_apply` (default true).
+  Example: `ops: [{ op: "replace_lines", from_line: 15, to_line: 15, text: "hello world" }]`.
 - `improve_frontmatter`: normalizes/adds required frontmatter keys (and typed-link key normalization).  
   Required: `path`.  
   Options: `expected_sha256`, `apply` (default false), `reindex_after_apply` (default true), `fix_identity` (default false).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -69,6 +69,7 @@ Explicit write tools (apply, implemented):
 
 - `capture_note`: capture a new inbox note with required frontmatter (default folder: `100. Inbox`; supports dry-run)
 - `edit_note`: apply line-based patch ops to an existing note (supports dry-run and optional sha256 guard; reindexes by default)
+  - Example: `ops: [{ op: "replace_lines", from_line: 15, to_line: 15, text: "hello world" }]`
 - `improve_frontmatter`: normalize/add required frontmatter keys for a note (supports dry-run; can optionally fix identity mismatches)
 - `relocate_note`: move/rename a note within the vault (supports dry-run; updates frontmatter `updated` when present)
 


### PR DESCRIPTION
## What

- Simplified the edit_note tool ops input schema so MCP clients render it as an array of objects (instead of misrepresenting it
as string[]).
- Preserved runtime behavior by keeping the existing line-based patch application (applyLinePatchOps) and only changing schema/validation + normalization.
- Added a concrete ops example to user-facing docs so tool callers have a copy-pasteable shape.

## Why

- Some MCP clients (including Codex) can mis-handle/over-simplify complex JSON Schema produced from zod unions, causing edit_note.ops to appear as string[].
- That UI/schema mismatch leads callers to send invalid payloads (e.g., ops: ["help"]) and triggers MCP validation failures like -32602 invalid params (server expects objects, not strings).
- Reducing schema complexity improves interoperability across MCP clients while keeping server-side validation authoritative.

## How

- Replaced ops: z.array(z.union([insert|delete|replace])) with ops: z.array(linePatchOpSchema) where
  - linePatchOpSchema.op is enum(["insert_lines", "delete_lines", "replace_lines"])
  - at_line, from_line, to_line, text are optional fields described in-schema
  - superRefine enforces op-specific required fields at runtime (e.g., insert_lines requires at_line + text)
- Added normalizeLinePatchOp() to convert the simplified input object into the existing internal LinePatchOp union before
calling applyLinePatchOps.
- Updated docs with a minimal example payload
  - ops: [{ op: "replace_lines", from_line: 15, to_line: 15, text: "hello world" }]