### PR TITLE
chore: standardize folder names in injected prompts

### DIFF
--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -111,7 +111,7 @@ cites: ["[[Some Note]]"]
 - Titles are filenames: keep them cross-device safe (especially for Sync).
   - Avoid: `\\` `/` `:` `*` `?` `"` `<` `>` `|` `#` `^` and `%%` / Obsidian wikilink brackets.
   - Prefer using only letters/numbers/spaces plus `-` and `_` when in doubt.
-- Default to English titles. Avoid translation parentheses (e.g. `한글(English)`); use frontmatter `aliases` for translations/alternate titles instead.
+- Default to English titles. Avoid translation parentheses (e.g. `Korean(English)`); use frontmatter `aliases` for translations/alternate titles instead.
 - If you need the full path in a wikilink (disambiguation), hide it with display text:
   - Example below
 

--- a/docs/standards/vault/vault-structure.md
+++ b/docs/standards/vault/vault-structure.md
@@ -2,8 +2,29 @@
 
 ## Top-level folders
 
-- Required top-level folders: `10. Projects`, `20. Areas`, `30. Resources`, `40. Archives`, `100. Inbox`.
-- Optional top-level folders (convenience): `0. System`, `1. Main` (and any additional folders you introduce intentionally).
+Canonical top-level folders (English, prompt-safe):
+
+| Folder          | Required | Role                                                     |
+| --------------- | -------- | -------------------------------------------------------- |
+| `10. Projects`  | Yes      | time-bounded projects and decisions                      |
+| `20. Areas`     | Yes      | long-lived responsibility areas                          |
+| `30. Resources` | Yes      | reference material and external summaries                |
+| `40. Archives`  | Yes      | inactive/finished material                               |
+| `100. Inbox`    | Yes      | capture inbox; triage regularly                          |
+| `0. System`     | No       | system rules, templates, scripts, and operational guides |
+| `1. Main`       | No       | top-level hubs and navigation indexes                    |
+
+Notes:
+
+- AILSS does **not** auto-rename/migrate existing vault folders.
+- If your inbox folder name differs, pass `folder` explicitly when calling `capture_note` (default: `100. Inbox`).
+
+### Non-canonical examples (avoid → use)
+
+| Avoid                                               | Use                  | Context                                          |
+| --------------------------------------------------- | -------------------- | ------------------------------------------------ |
+| localized/non-English folder names                  | English folder names | keep paths stable and prompt examples consistent |
+| inconsistent spacing/punctuation (e.g. `100.Inbox`) | `100. Inbox`         | canonical inbox folder name                      |
 
 ## Immediate improvement actions
 
@@ -15,7 +36,7 @@ This document summarizes the AILSS vault structure, naming, and linking conventi
 
 ## Naming and asset placement
 
-- Filenames: default to an English title (example: `Domain-Driven Design.md`). Avoid adding translations in parentheses (e.g. `한글(English)`); use parentheses only for disambiguation.
+- Filenames: default to an English title (example: `Domain-Driven Design.md`). Avoid adding translations in parentheses (e.g. `Korean(English)`); use parentheses only for disambiguation.
   - If you want searchable alternate titles/translations (e.g. Korean), put them in frontmatter `aliases` instead.
 - Filenames (cross-device safe): avoid characters/sequences that can break links or Sync on other OSes.
   - Avoid: `\\` `/` `:` `*` `?` `"` `<` `>` `|` `#` `^` and `%%` / Obsidian wikilink brackets.
@@ -25,7 +46,7 @@ This document summarizes the AILSS vault structure, naming, and linking conventi
 
 ### Folder creation and naming rules
 
-- Folder naming: two-digit prefix + space + English title (example: `12. Data Quality`). Avoid adding translations in parentheses (e.g. `한글(English)`); use parentheses only for disambiguation.
+- Folder naming: two-digit prefix + space + English title (example: `12. Data Quality`). Avoid adding translations in parentheses (e.g. `Korean(English)`); use parentheses only for disambiguation.
 - Apply the same rule to subfolders, but keep the maximum depth to 3 levels from the top-level folder.
   - Example: `12. Data Quality/20. Monitoring`
 - When creating a new folder, also create an `assets/` subfolder, and embed assets only via relative paths.
@@ -72,7 +93,7 @@ Examples:
 [[Note title]]
 [[Note title|Display text]]
 [[path/to/note|Title]]
-[[20. Areas/30. SOPT/코드 리뷰/PROMPT|PROMPT]]
+[[20. Areas/30. SOPT/Code Review/PROMPT|PROMPT]]
 [[20. Areas/70. Claude Code/Commands/write-pr|write-pr]]
 [[Note#Section]]
 [[Note#^id]]

--- a/docs/standards/vault/vault-structure.md
+++ b/docs/standards/vault/vault-structure.md
@@ -4,15 +4,13 @@
 
 Canonical top-level folders (English, prompt-safe):
 
-| Folder          | Required | Role                                                     |
-| --------------- | -------- | -------------------------------------------------------- |
-| `10. Projects`  | Yes      | time-bounded projects and decisions                      |
-| `20. Areas`     | Yes      | long-lived responsibility areas                          |
-| `30. Resources` | Yes      | reference material and external summaries                |
-| `40. Archives`  | Yes      | inactive/finished material                               |
-| `100. Inbox`    | Yes      | capture inbox; triage regularly                          |
-| `0. System`     | No       | system rules, templates, scripts, and operational guides |
-| `1. Main`       | No       | top-level hubs and navigation indexes                    |
+| Folder          | Required | Role                                      |
+| --------------- | -------- | ----------------------------------------- |
+| `10. Projects`  | Yes      | time-bounded projects and decisions       |
+| `20. Areas`     | Yes      | long-lived responsibility areas           |
+| `30. Resources` | Yes      | reference material and external summaries |
+| `40. Archives`  | Yes      | inactive/finished material                |
+| `100. Inbox`    | Yes      | capture inbox; triage regularly           |
 
 Notes:
 
@@ -63,8 +61,6 @@ part_of: ["[[parent hub]]"]
 
 ## Folder roles (vault structure principles)
 
-- `0. System` (optional) — system rules, templates, scripts, and operational guides (mostly physical).
-- `1. Main` (optional) — top-level hubs and navigation indexes.
 - `10. Projects` — time-bounded projects and decisions (strategic/logical notes may coexist).
 - `20. Areas` — long-lived responsibility areas (conceptual + operational mix is normal).
 - `30. Resources` — reference material and external summaries (mostly conceptual).


### PR DESCRIPTION
## What

- Standardize folder-name/path examples in injected prompts/docs to a single English canonical set.
- Pin canonical required top-level vault folders (`10. Projects`, `20. Areas`, `30. Resources`, `40. Archives`, `100. Inbox`) in the vault structure doc.

## Why

- Keep injected prompt guidance aligned with the actual defaults used by AILSS tools (e.g. `capture_note` default folder).
- Reduce user confusion without performing any automatic vault folder migrations.

Fixes N/A

## How

- Update `docs/standards/vault/vault-structure.md` to define only the required canonical folder set and remove localized path examples.
- Update `docs/ops/codex-skills/prometheus-agent/SKILL.md` to keep prompt-safe examples English-only.
- Validation: `pnpm build`
- Validation: `pnpm check`
