### PR TITLE
feat: default get_context top_k from plugin setting

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -30,6 +30,7 @@ Example tools:
 Read-first tools (implemented in this repo):
 
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
+  - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
 - `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges; includes `links_to`)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -65,6 +65,7 @@ Notes:
 Optional:
 
 - `AILSS_ENABLE_WRITE_TOOLS=1` (enables explicit write tools like `edit_note`)
+- `AILSS_GET_CONTEXT_DEFAULT_TOP_K=<n>` (sets the default `get_context.top_k` when the caller omits `top_k`; clamped to 1–50; default: 10)
 
 ### Test tools with MCP Inspector (optional)
 

--- a/packages/mcp/src/tools/getContext.ts
+++ b/packages/mcp/src/tools/getContext.ts
@@ -10,6 +10,8 @@ import { embedQuery } from "../lib/openaiEmbeddings.js";
 import { readVaultFileText } from "../lib/vaultFs.js";
 
 export function registerGetContextTool(server: McpServer, deps: McpToolDeps): void {
+  const defaultTopK = parseDefaultTopKFromEnv(process.env.AILSS_GET_CONTEXT_DEFAULT_TOP_K);
+
   server.registerTool(
     "get_context",
     {
@@ -23,7 +25,7 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
           .int()
           .min(1)
           .max(50)
-          .default(10)
+          .default(defaultTopK)
           .describe("Maximum number of note results to return (1–50)"),
         max_chars_per_note: z
           .number()
@@ -125,4 +127,19 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
       };
     },
   );
+}
+
+function parseDefaultTopKFromEnv(raw: string | undefined): number {
+  const defaultTopK = 10;
+  if (!raw) return defaultTopK;
+  const trimmed = raw.trim();
+  if (!trimmed) return defaultTopK;
+
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) return defaultTopK;
+
+  const n = Math.floor(parsed);
+  if (n < 1) return 1;
+  if (n > 50) return 50;
+  return n;
 }

--- a/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
+++ b/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import http from "node:http";
 
 import { DEFAULT_SETTINGS, type AilssObsidianSettings } from "../settings.js";
-import { clampPort } from "../utils/clamp.js";
+import { clampPort, clampTopK } from "../utils/clamp.js";
 import { appendLimited, nowIso } from "../utils/misc.js";
 import { nodeNotFoundMessage, resolveSpawnCommandAndEnv } from "../utils/spawn.js";
 import { waitForTcpPortToBeAvailable } from "../utils/tcp.js";
@@ -92,6 +92,12 @@ export class McpHttpServiceController {
 				await this.deps.saveSettings();
 			}
 
+			const topK = clampTopK(settings.topK);
+			if (topK !== settings.topK) {
+				settings.topK = topK;
+				await this.deps.saveSettings();
+			}
+
 			const host = "127.0.0.1";
 			let portAvailable = await waitForTcpPortToBeAvailable({
 				host,
@@ -142,6 +148,7 @@ export class McpHttpServiceController {
 				AILSS_MCP_HTTP_PATH: "/mcp",
 				AILSS_MCP_HTTP_TOKEN: token,
 				AILSS_MCP_HTTP_SHUTDOWN_TOKEN: shutdownToken,
+				AILSS_GET_CONTEXT_DEFAULT_TOP_K: String(topK),
 			};
 
 			if (settings.mcpHttpServiceEnableWriteTools) {


### PR DESCRIPTION
## What

- MCP: Default `get_context.top_k` from `AILSS_GET_CONTEXT_DEFAULT_TOP_K` when omitted (clamped to 1–50; fallback 10).
- Plugin: Inject `AILSS_GET_CONTEXT_DEFAULT_TOP_K` from the plugin Top K setting when spawning the MCP HTTP service.
- Docs: Document the env option and "only applies when the caller omits `top_k`."

## Why

- Keep Codex/clients consistent with the plugin-configured Top K when they don't pass `top_k`.
- Avoid hardcoded defaults drifting between the plugin and the MCP server.
- Fixes: N/A

## How

- Parse and clamp the env once at tool registration and use Zod `.default(...)`.
- Clamp the plugin setting (1–50) before exporting it to the service process env.
- Add tests for env unset/invalid and clamp edge cases.
- Validation: `pnpm check`
