### PR TITLE
docs: create assets folders only when needed

### DIFF
--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -9,7 +9,7 @@ Global working rules for the AILSS Obsidian vault.
 - Split notes into frontmatter (metadata) and body (content), and record semantic relations only as typed links in frontmatter.
 - After semantic analysis, review and add any typed links that should exist (don’t stop at the existing ones).
 - Use wikilinks freely in the body, but check for broken links before and after work.
-- Keep assets in a note-adjacent `assets/` folder and embed them via relative paths.
+- When you have local assets (images, PDFs, diagrams, etc.), keep them in a note-adjacent `assets/` folder and embed them via relative paths.
 - MCP tool usage is mandatory: before summarizing/classifying/reviewing, query MCP tools to retrieve authoritative note text/metadata.
 
 ## Curation and PR hygiene
@@ -80,7 +80,7 @@ Global working rules for the AILSS Obsidian vault.
 - Typed links: review the coverage checklist items (`instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `same_as`, `supersedes`).
 - Coverage log: keep semantic retrieval + literal checks together (what `get_context` returned, and what `read_note` confirmed).
 - Links: run `find_broken_links` (preferred) and fix unresolved targets; fall back to `rg "\\[\\[" -n` if needed.
-- Assets: ensure a note-adjacent `assets/` folder exists; avoid absolute/external file paths.
+- Assets: if a folder contains local assets, ensure a note-adjacent `assets/` folder exists (create it when adding the first asset); avoid absolute/external file paths.
 - MCP: keep a log of MCP calls before summarizing/classifying/reviewing.
 - After: record changed file paths and entity/layer changes.
 - Rationale: confirm rationale was explained in chat (not inserted into note bodies).

--- a/docs/standards/vault/vault-structure.md
+++ b/docs/standards/vault/vault-structure.md
@@ -47,7 +47,7 @@ This document summarizes the AILSS vault structure, naming, and linking conventi
 - Folder naming: two-digit prefix + space + English title (example: `12. Data Quality`). Avoid adding translations in parentheses (e.g. `Korean(English)`); use parentheses only for disambiguation.
 - Apply the same rule to subfolders, but keep the maximum depth to 3 levels from the top-level folder.
   - Example: `12. Data Quality/20. Monitoring`
-- When creating a new folder, also create an `assets/` subfolder, and embed assets only via relative paths.
+- `assets/` subfolder: create it only when the folder contains local assets (images, PDFs, diagrams, etc.); avoid creating empty `assets/` folders. Embed assets only via relative paths.
 - The first note in a folder should be a hub note, and the filename should match the folder name.
   - Suggested frontmatter (example below)
 - After folder moves/creation, re-check broken links and update child notes’ `part_of` to the new hub note.


### PR DESCRIPTION
## What

- Update vault docs so `assets/` subfolders are created only when local assets exist.
- Clarify TL;DR/checklist wording for assets placement and creation timing.

## Why

- Avoid cluttering the vault with empty `assets/` folders (empty directories are not tracked by git).
- Keep guidance aligned with actual usage: create `assets/` when you add the first asset.

## How

- Update `docs/standards/vault/vault-structure.md` folder creation rule to be conditional.
- Update `docs/standards/vault/assistant-workflow.md` TL;DR + checklist to reflect on-demand creation.
- Validation: `pnpm check` (format:check, lint, typecheck, typecheck:repo, tests)
