### PR TITLE
docs: require lowercase pr titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ This repo recommends Conventional Commits.
 
 - Title format: `<type>: <title>`
   - Allowed `type`: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`
+  - `<title>` must start with a lowercase letter (e.g. `feat: add ...`, not `feat: Add ...`)
 - Body: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
 - Language: PR title and body must be written in English.
 - Sections: for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).


### PR DESCRIPTION
## What

- Require PR title `<title>` to start with a lowercase letter

## Why

- Keep PR titles consistent with the repo convention
- Reduce review churn around title casing

## How

- Update `AGENTS.md` PR title convention
- Testing: Not run (docs-only change)
