### PR TITLE
docs: make Fixes line optional

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 [REPLACE ME]
 
-- Fixes #<issue-number> (optional; delete if N/A)
+- Fixes #<issue-number> (optional; delete if not applicable)
 
 ## How
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 [REPLACE ME]
 
-Fixes #<issue-number> (or N/A)
+- Fixes #<issue-number> (optional; delete if N/A)
 
 ## How
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ This repo recommends Conventional Commits.
 - Sections: for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).
 - Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).
 - Testing: include the exact validation commands you ran (or explicitly state `Not run` and why).
-- Issues: fill `Fixes #...` when applicable; otherwise write `N/A`.
+- Issues: include `Fixes #...` when applicable; omit the line otherwise.
 
 ---
 


### PR DESCRIPTION
## What

- Make the `Fixes` line optional in the PR template and conventions

## Why

- Avoid noise from a `Fixes` placeholder when there is no linked issue
- Keep the `## Why` section bullet-only

## How

- Update `.github/pull_request_template.md` to make the `Fixes #...` bullet optional
- Update `AGENTS.md` to omit the line when not applicable
- Testing: Not run (docs-only change)
