### PR TITLE
chore: add markdown issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,45 @@
+---
+name: Bug report (Markdown)
+about: Report a reproducible problem in AILSS (Markdown template)
+title: "bug: "
+labels: ["bug"]
+---
+
+Please include a minimal repro and relevant logs.
+Do not paste API keys or private note content.
+
+## Component
+
+Where is the issue happening?
+
+- [ ] Indexer (`packages/indexer`)
+- [ ] MCP server (`packages/mcp`)
+- [ ] Obsidian plugin (`packages/obsidian-plugin`)
+- [ ] Core/shared (`packages/core`)
+- [ ] Docs
+- [ ] Not sure
+
+## What happened?
+
+What did you do, what happened, and what did you expect?
+
+## Steps to reproduce
+
+Minimal steps so we can reproduce:
+
+1.
+2.
+3.
+
+## Logs / output (redact secrets)
+
+Paste relevant stdout/stderr. Please redact API keys and private note content.
+
+```text
+
+```
+
+## Confirmations
+
+- [ ] I confirm I did not include API keys or other secrets in this issue
+- [ ] I can reproduce this on the latest `main` (or I included the exact commit SHA I tested)

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,20 @@
+---
+name: Documentation issue (Markdown)
+about: Report missing/incorrect docs (Markdown template)
+title: "docs: "
+labels: ["documentation"]
+---
+
+## Doc location
+
+Which doc needs updating?
+
+Example: `docs/ops/local-dev.md`, `README.md`, ...
+
+## What’s wrong / missing?
+
+Describe the doc problem and what you expected to see.
+
+## Suggested fix (optional)
+
+Proposed wording, command, or link.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request (Markdown)
+about: Suggest an improvement or new capability (Markdown template)
+title: "feat: "
+labels: ["enhancement"]
+---
+
+## Problem statement
+
+What problem are you trying to solve?
+
+## Proposed solution
+
+What would you like to happen?
+
+## Constraints / context (optional)
+
+Any constraints or context we should know?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,24 @@
+---
+name: Question / support (Markdown)
+about: Ask a question about setup, usage, or behavior (Markdown template)
+title: "question: "
+labels: ["question"]
+---
+
+## Your question
+
+What are you trying to do, and what’s blocking you?
+
+## Context (optional)
+
+Commands you ran, settings you changed, and what happened.
+
+## Logs / output (redact secrets)
+
+```text
+
+```
+
+## Confirmations
+
+- [ ] I confirm I did not include API keys or other secrets in this issue


### PR DESCRIPTION
## What

- Add Markdown issue templates alongside existing Issue Forms (YAML)

## Why

- Evaluate both formats side-by-side
- Support contributors who prefer Markdown templates

## How

- Add `.github/ISSUE_TEMPLATE/*.md` equivalents for bug/feature/docs/question
- Keep titles/labels aligned with the existing YAML forms
- Validation: Not run (template-only change)
