### PR TITLE
docs: broaden Prometheus Agent skill description

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ In the Obsidian plugin settings, use **Copy Prometheus Agent skill (Codex)** and
 
 - Recommended path: `~/.codex/skills/ailss-prometheus-agent/SKILL.md`
 - Snapshot reference: `docs/ops/codex-skills/prometheus-agent/SKILL.md`
+- Tip: the skill description includes Obsidian/vault/frontmatter keywords to improve implicit skill selection for note-related requests.
 
 We intentionally avoid per-project/workspace `AGENTS.md` prompts and keep guidance in these two channels only: vault-root prompt + Codex skill.
 

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ailss-prometheus-agent
-description: Retrieval-first AILSS vault workflow for Codex CLI (MCP read tools first; explicit gated writes)
+description: "Obsidian vault notes (AILSS): search/summarize/edit (frontmatter, tags/keywords, typed links/backlinks, broken links; retrieval-first MCP; gated writes)"
 mcp_tools:
   # Always available (read tools)
   - get_context


### PR DESCRIPTION
## What

- Broadened the Prometheus Agent Codex skill `description` to include common Obsidian/vault/frontmatter keywords for better implicit selection.
- Added a short README note documenting the intent of the description keywords.

## Why

- Improve implicit skill selection when users ask about Obsidian notes/vault/frontmatter without explicitly naming the skill.
- Keep the skill snapshot and install guidance aligned.

## How

- Updated YAML frontmatter `description` in `docs/ops/codex-skills/prometheus-agent/SKILL.md`.
- Documented the behavior in `README.md`.
- Validation: Not run (docs-only change).
