### PR TITLE
ci: drop v prefix from release title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,7 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: v${{ steps.meta.outputs.version }}
+          name: ${{ steps.meta.outputs.version }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## What

- Remove the leading `v` from the GitHub Release title while keeping `v*` tags

## Why

- Match the agreed convention: tag has `v`, release title does not
- Refs #21

## How

- Change `softprops/action-gh-release` `name:` to use the tag-derived version (already stripped of `v`)
- Validation: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); puts 'YAML OK'"`
