### PR TITLE
feat: remove see_also typed link key

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ Typed links are optional frontmatter keys used to record semantic edges as wikil
 - `part_of`: composition / parent hub (“is part of”)
 - `depends_on`, `uses`: dependencies (“needs/uses”)
 - `implements`: implementation of a spec/standard/procedure
-- `see_also`: related notes
 - `cites`: citation to other vault notes (use `source` for external sources)
 - `authored_by`: authorship / attribution
 - `same_as`, `supersedes`: equivalence / replacement

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -30,7 +30,7 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 
 1. Start with `get_context` for the user’s query (avoid guessing and avoid duplicates).
 2. Use `get_typed_links` to navigate the semantic graph from a specific note (DB-backed).
-   - Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements/see_also; do not add reciprocal links unless explicitly requested.
+   - Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements; do not add reciprocal links unless explicitly requested.
 3. Use `resolve_note` when you only have `id`/`title`/a wikilink target and need a vault-relative path for `read_note`/`edit_note`.
 4. Use `read_note` to confirm exact wording and frontmatter before making claims.
 5. Use `search_notes` for metadata filtering (entity/layer/status/tags/keywords/source/date ranges) without embeddings calls.
@@ -56,7 +56,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
 - For metadata filtering (entity/layer/status/tags/keywords/source/date ranges), use `search_notes` (DB-only; no embeddings).
 - Before adding new tags/keywords, prefer reusing existing vocabulary via `list_tags` / `list_keywords`.
 - If you need typed-link navigation starting from a specific note path, call `get_typed_links` (outgoing only; bounded graph).
-- Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements/see_also; do not add reciprocal links unless explicitly requested.
+- Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements; do not add reciprocal links unless explicitly requested.
 - If you are unsure what tools exist or what arguments they require, call `tools/list` and follow the returned schemas exactly.
 
 ### Structure + validation
@@ -89,7 +89,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
   - `source` is always an array (example: `source: []`)
 - `layer`: `strategic` | `conceptual` | `logical` | `physical` | `operational`
 - `status`: `draft` | `in-review` | `active` | `archived`
-- Typed-link keys (only include when non-empty; omit key when you have no values): `instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `see_also`, `cites`, `authored_by`, `supersedes`, `same_as`
+- Typed-link keys (only include when non-empty; omit key when you have no values): `instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `authored_by`, `supersedes`, `same_as`
 - `entity` candidates (use one of these; do not invent new values):
   - `concept` | `document` | `project` | `artifact` | `person` | `organization` | `place` | `event` | `task` | `method` | `tool` | `idea` | `principle` | `heuristic` | `pattern` | `definition` | `question` | `software` | `dataset` | `pipeline` | `procedure` | `dashboard` | `checklist` | `workflow` | `decide` | `review` | `plan` | `implement` | `approve` | `reject` | `observe` | `measure` | `test` | `verify` | `learn` | `research` | `summarize` | `publish` | `meet` | `audit` | `deploy` | `rollback` | `refactor` | `design` | `delete` | `update` | `create` | `schedule` | `migrate` | `reference` | `hub` | `interface` | `guide` | `log` | `structure` | `architecture` | `analyze`
 - External vs internal sources:

--- a/docs/standards/vault/frontmatter-schema.md
+++ b/docs/standards/vault/frontmatter-schema.md
@@ -59,7 +59,6 @@ Supported keys:
 - `part_of` (composition)
 - `depends_on`, `uses` (dependencies)
 - `implements` (implementation)
-- `see_also` (related, non-directional)
 - `cites` (citation to other vault notes)
 - `authored_by` (authorship/attribution)
 - `supersedes` (replacement/versioning)
@@ -197,7 +196,6 @@ status: draft
 updated: {{date:YYYY-MM-DDTHH:mm:ss}}
 source: []
 instance_of: ['[[concept]]']
-see_also: ['[[Ubiquitous Language]]']
 ---
 ```
 

--- a/docs/standards/vault/typed-links.md
+++ b/docs/standards/vault/typed-links.md
@@ -16,7 +16,6 @@ AILSS indexes and queries typed links by these frontmatter keys:
 - Composition (part/whole): `part_of`
 - Dependency: `depends_on`, `uses`
 - Implementation: `implements`
-- Related: `see_also`
 - Citation: `cites`
 - Authorship / attribution: `authored_by`
 - Equivalence / versioning: `same_as`, `supersedes`
@@ -67,7 +66,7 @@ Notes:
 
 - Concept (`entity: concept`)
   - Required: `instance_of` (concept wikilink; see example snippet below)
-  - Recommended: `see_also`, `cites`
+  - Recommended: `cites`
 - Document (`entity: document`)
   - Required: `part_of`
   - Recommended: `cites`, and optionally `same_as` (duplicates), `supersedes` (newer replacement)
@@ -78,7 +77,7 @@ Notes:
   - Required: `implements` (pipeline/policy), `uses` (tools)
   - Recommended: `cites` (reference docs)
 - Software / tool (`entity: software` or `entity: tool`)
-  - Recommended: `part_of` (ecosystem/hub), `depends_on` (runtime/framework), `see_also`
+  - Recommended: `part_of` (ecosystem/hub), `depends_on` (runtime/framework)
 - Dataset (`entity: dataset`)
   - Recommended: `part_of` (domain), `depends_on` (schema/source), `cites` (origin)
 

--- a/packages/core/src/vault/frontmatter.ts
+++ b/packages/core/src/vault/frontmatter.ts
@@ -7,7 +7,6 @@ export const AILSS_TYPED_LINK_KEYS = [
   "depends_on",
   "uses",
   "implements",
-  "see_also",
   "cites",
   "authored_by",
   "supersedes",

--- a/packages/mcp/src/lib/ailssNoteTemplate.ts
+++ b/packages/mcp/src/lib/ailssNoteTemplate.ts
@@ -161,7 +161,6 @@ export function renderFrontmatterYaml(frontmatter: AilssFrontmatter): string {
     "uses",
     "depends_on",
     "implements",
-    "see_also",
     "cites",
     "authored_by",
     "supersedes",

--- a/packages/mcp/src/tools/suggestTypedLinks.ts
+++ b/packages/mcp/src/tools/suggestTypedLinks.ts
@@ -164,7 +164,8 @@ export function registerSuggestTypedLinksTool(server: McpServer, deps: McpToolDe
 
         const targetMeta = getMetaCached(resolvedPath);
         const targetEntity = (targetMeta?.entity ?? "").trim().toLowerCase();
-        const rel = ENTITY_HINT_USES.has(targetEntity) ? "uses" : "see_also";
+        if (!ENTITY_HINT_USES.has(targetEntity)) continue;
+        const rel = "uses";
 
         const existingSet = existingByRel.get(rel);
         if (existingSet && existingSet.has(target)) {
@@ -187,10 +188,9 @@ export function registerSuggestTypedLinksTool(server: McpServer, deps: McpToolDe
             title: r.title,
             matched_by: r.matchedBy,
           })),
-          reason:
-            rel === "uses" && targetMeta?.entity
-              ? `target entity=${JSON.stringify(targetMeta.entity)}`
-              : "default see_also from body wikilink",
+          reason: targetMeta?.entity
+            ? `target entity=${JSON.stringify(targetMeta.entity)}`
+            : "target entity missing",
         });
       }
 

--- a/packages/mcp/test/httpTools.getTypedLinks.test.ts
+++ b/packages/mcp/test/httpTools.getTypedLinks.test.ts
@@ -62,7 +62,7 @@ describe("MCP HTTP server (get_typed_links)", () => {
             now,
           );
 
-          linkStmt.run("A.md", "see_also", "B", "[[B]]", 0, now);
+          linkStmt.run("A.md", "cites", "B", "[[B]]", 0, now);
 
           const sessionId = await mcpInitialize(url, token, "client-a");
           const res = await mcpToolsCall(url, token, sessionId, "get_typed_links", {

--- a/packages/mcp/test/httpTools.suggestTypedLinks.test.ts
+++ b/packages/mcp/test/httpTools.suggestTypedLinks.test.ts
@@ -93,20 +93,14 @@ describe("MCP HTTP server (suggest_typed_links)", () => {
 
           const suggestions = structured["suggestions"];
           assertArray(suggestions, "suggestions");
-          expect(suggestions.length).toBe(2);
+          expect(suggestions.length).toBe(1);
 
           const s0 = suggestions[0];
-          const s1 = suggestions[1];
           assertRecord(s0, "suggestions[0]");
-          assertRecord(s1, "suggestions[1]");
 
           expect(s0["rel"]).toBe("uses");
           expect(s0["target"]).toBe("Tool");
           expect(String(s0["suggested_wikilink"])).toBe("[[Tool|Tool Title]]");
-
-          expect(s1["rel"]).toBe("see_also");
-          expect(s1["target"]).toBe("Concept");
-          expect(String(s1["suggested_wikilink"])).toBe("[[Concept]]");
         },
       );
     });


### PR DESCRIPTION
## What

- Remove `see_also` from the supported typed-link key set
- Stop emitting `see_also` in MCP frontmatter templates
- Remove `see_also` fallback from typed-link suggestions and align tests
- Update docs and the Prometheus Agent skill to match the new ontology

## Why

- `see_also` is intentionally out of the ontology (option B); relationships must be expressed via precise keys only
- Refs #26

## How

- Update canonical key list in `@ailss/core`
- Update template emission and `suggest_typed_links` behavior in `@ailss/mcp`
- Update documentation references/examples
- Validation:
  - `pnpm -w build`
  - `pnpm -w typecheck`
  - `pnpm -w test`
