### PR TITLE
docs: stop recommending body wikilinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ Typed links are optional frontmatter keys used to record semantic edges as wikil
 - `authored_by`: authorship / attribution
 - `same_as`, `supersedes`: equivalence / replacement
 
-Note: AILSS also extracts body wikilinks and stores them as `typed_links` edges with `rel: links_to`.
+Note: AILSS also extracts body wikilinks (if present) and stores them as `typed_links` edges with `rel: links_to` for non-semantic navigation/backrefs.
+This is optional and not part of the recommended authoring workflow.
 You should not write `links_to` in frontmatter.
 
 ## MCP tools
@@ -181,7 +182,7 @@ The list below reflects the current MCP tool surface. For broader architecture d
 - `list_keywords`: lists indexed keywords with usage counts (helps reuse existing vocabulary).  
   Required: none.  
   Options: `limit` (default 200, 1–5000).
-- `suggest_typed_links`: proposes frontmatter typed-link candidates from body wikilinks (DB-only).  
+- `suggest_typed_links`: proposes frontmatter typed-link candidates from already-indexed `links_to` edges (typically derived from body wikilinks, if present) (DB-only).  
   Required: `path`.  
   Options: `max_links_to_consider` (default 500), `max_suggestions` (default 100), `max_resolutions_per_target` (default 5).
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -41,7 +41,7 @@ Read-first tools (implemented in this repo):
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
-- `suggest_typed_links`: suggest frontmatter typed-link candidates using already-indexed body wikilinks (DB-backed)
+- `suggest_typed_links`: suggest frontmatter typed-link candidates using already-indexed `links_to` edges (typically derived from body wikilinks, if present) (DB-backed)
 
 Client guidance (Codex):
 

--- a/docs/architecture/data-db.md
+++ b/docs/architecture/data-db.md
@@ -62,7 +62,7 @@ Simple mapping tables for fast filtering without relying on sqlite JSON function
 
 ### `typed_links`
 
-Stores “typed links” as graph edges (frontmatter relations and body wikilinks).
+Stores “typed links” as graph edges (frontmatter relations and optional body wikilinks, if present).
 
 - `from_path`: vault-relative source note path
 - `rel`: relation key (e.g. `part_of`, `depends_on`, `links_to`)
@@ -92,7 +92,7 @@ Example `to_wikilink` value:
 1. Scan for `.md` files in the vault (default ignores: `.obsidian`, `.git`, `.trash`, `.ailss`, etc.)
 2. Compare the file sha256 to the DB; if it differs, treat as “changed”
 3. Upsert `files`
-4. Parse Markdown into `frontmatter` + `body`, normalize frontmatter fields + typed links, extract body wikilinks as `links_to`, and upsert:
+4. Parse Markdown into `frontmatter` + `body`, normalize frontmatter fields + typed links, extract body wikilinks (if present) as `links_to`, and upsert:
    - `notes`, `note_tags`, `note_keywords`, `note_sources`, `typed_links`
 5. Chunk the Markdown body by headings (with `maxChars`) and compute stable chunk IDs per file
 6. Compare existing chunks for that file to the next chunk set:

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -8,7 +8,7 @@ Global working rules for the AILSS Obsidian vault.
 - For any claim grounded in a single web page/document, retrieve the original text via Fetch. For vault knowledge, query AILSS MCP first.
 - Split notes into frontmatter (metadata) and body (content), and record semantic relations only as typed links in frontmatter.
 - After semantic analysis, review and add any typed links that should exist (don’t stop at the existing ones).
-- Use wikilinks freely in the body, but check for broken links before and after work.
+- Avoid adding new body wikilinks as part of the standard workflow; record relationships via frontmatter typed links and check for broken links before and after work.
 - When you have local assets (images, PDFs, diagrams, etc.), keep them in a note-adjacent `assets/` folder and embed them via relative paths.
 - MCP tool usage is mandatory: before summarizing/classifying/reviewing, query MCP tools to retrieve authoritative note text/metadata.
 

--- a/docs/standards/vault/typed-links.md
+++ b/docs/standards/vault/typed-links.md
@@ -4,7 +4,7 @@
 
 - Record semantic relations only as typed links in YAML frontmatter.
 - Record them only in the forward direction. Incoming/back-references are derived by queries/graphs.
-- In the note body, use wikilinks freely, but if a relationship is semantic, promote it into frontmatter as a typed link.
+- Avoid adding new body wikilinks as part of the standard workflow; record semantic relations as typed links in YAML frontmatter.
 - Don’t stop at “what already exists”. After semantic analysis, consider which links _should_ exist and add the missing ones.
 - The relationship fields are optional to _fill_, but omit the key when you have no values (do not keep empty arrays). If the note implies a relationship, use typed links so the graph is queryable.
 
@@ -34,20 +34,21 @@ To introduce a new typed-link key, update **all** of the above in the same chang
 
 Notes:
 
-- AILSS also extracts **body** wikilinks and stores them as edges with `rel: links_to`.
+- AILSS also extracts **body** wikilinks (if present) and stores them as edges with `rel: links_to` for non-semantic navigation/backrefs.
+  - This is optional and not part of the recommended authoring workflow; prefer frontmatter typed links for semantic relations.
   - `links_to` is **not** a frontmatter relation key you should write yourself; it is reserved for body-link extraction and navigation/backrefs.
 
 ### How AILSS uses typed links (implementation notes)
 
 - Typed links are extracted from frontmatter into a structured edge list (stored as `typed_links` in the index DB).
 - The `get_typed_links` tool reads those edges and expands outgoing links into a bounded graph (metadata only).
-- Body wikilinks are also extracted and stored as `typed_links` edges with `rel: links_to` for non-semantic navigation and backrefs.
+- Body wikilinks (if present) are also extracted and stored as `typed_links` edges with `rel: links_to` for non-semantic navigation and backrefs.
   - Use frontmatter typed links when the relationship is semantic (so queries/graphs can distinguish it from `links_to`).
 
 ### Workflow: derive relationships from semantic analysis
 
 1. Identify the target note **S** (identity): confirm `title`, `entity`, `layer`, `summary` first.
-2. Collect candidates: extract noun phrases from the body wikilinks, file path, and existing frontmatter.
+2. Collect candidates: extract noun phrases from the body text, file path, and existing frontmatter.
 3. Semantic retrieval: use `get_context` with the following question templates (to gather candidates):
    - “S is a kind of ?” → `instance_of` candidates
    - “S is part of ?” → `part_of` candidates


### PR DESCRIPTION
## What

- Stop recommending body wikilinks as part of the standard authoring workflow
- Clarify that `links_to`/body wikilinks are optional and primarily for non-semantic navigation/backrefs
- Update `suggest_typed_links` docs wording to reflect that it relies on already-indexed `links_to` edges

## Why

- Align written guidance with the intended convention: semantic relationships should be expressed via frontmatter typed links
- Fixes #28

## How

- Update vault rules docs (`docs/standards/vault/*`) to remove/soften “use wikilinks freely in the body” guidance
- Update overview/architecture docs (`README.md`, `docs/01-overview.md`, `docs/architecture/data-db.md`) to treat body links as optional
- Validation:
  - `pnpm -w build`
  - `pnpm -w check`
