### PR TITLE
ci: categorize release notes and auto-label prs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,41 @@
+plugin:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/obsidian-plugin/**
+
+mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/mcp/**
+
+indexer:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/indexer/**
+
+core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/core/**
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+
+ops:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+          - scripts/**
+          - commitlint.config.cjs
+          - eslint.config.mjs
+          - lefthook.yml
+          - package.json
+          - pnpm-lock.yaml
+          - pnpm-workspace.yaml
+          - prettier.config.cjs
+          - tsconfig.base.json
+          - tsconfig.json
+          - vitest.config.ts

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,27 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Obsidian Plugin
+      labels:
+        - plugin
+    - title: MCP Server
+      labels:
+        - mcp
+    - title: Indexer CLI
+      labels:
+        - indexer
+    - title: Core
+      labels:
+        - core
+    - title: CI / Ops / Monorepo
+      labels:
+        - ops
+        - monorepo
+    - title: Docs
+      labels:
+        - docs
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Apply labels
+        uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
## What

- Add `.github/release.yml` to split auto-generated GitHub Release notes into component sections
- Add PR auto-labeling via `actions/labeler` + `.github/labeler.yml`

## Why

- Make releases easier to scan by area (plugin vs MCP vs indexer)
- Reduce manual labeling overhead and keep categorization consistent
- Fixes #29

## How

- Configure release note categories based on PR labels (`plugin`, `mcp`, `indexer`, `core`, `ops`, `monorepo`, `docs`)
- Add a `pull_request_target` labeler workflow with minimal permissions (`contents: read`, `pull-requests: write`)
- Map paths to labels in `.github/labeler.yml`
