### PR TITLE
feat: lower get_context default max_chars_per_note

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The list below reflects the current MCP tool surface. For broader architecture d
 
 - `get_context`: semantic retrieval over the index DB with optional vault previews.  
   Required: `query` (string).  
-  Options: `top_k` (default 10, 1–50), `max_chars_per_note` (default 2000, 200–50,000).
+  Options: `top_k` (default 10, 1–50), `max_chars_per_note` (default 800, 200–50,000).
 - `get_typed_links`: expands outgoing typed-link graph from a seed note (DB-only; no note body reads).  
   Required: `path`.  
   Options: `max_notes` (default 50, 1–200), `max_edges` (default 2000, 1–10,000), `max_links_per_note` (default 40), `max_resolutions_per_target` (default 5).

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -31,6 +31,7 @@ Read-first tools (implemented in this repo):
 
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
   - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
+  - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000)
 - `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges; includes `links_to`)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)

--- a/packages/mcp/src/tools/getContext.ts
+++ b/packages/mcp/src/tools/getContext.ts
@@ -32,7 +32,7 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
           .int()
           .min(200)
           .max(50_000)
-          .default(2000)
+          .default(800)
           .describe("Preview size per note (characters)"),
       },
       outputSchema: z.object({


### PR DESCRIPTION
## What

- Lower the default `get_context.max_chars_per_note` from 2000 to 800.
- Update README to reflect the new default.

## Why

- Reduce tool payload size and downstream LLM context bloat when callers omit `max_chars_per_note`.
- Fixes #33

## How

- Adjust the `max_chars_per_note` schema default in `packages/mcp/src/tools/getContext.ts`.
- Update the `get_context` options line in `README.md`.
- Run `pnpm build` and `pnpm check`.
