### PR TITLE
fix: raise default MCP HTTP max sessions to 20

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,26 @@ This repo recommends Conventional Commits.
 - Testing: include the exact validation commands you ran (or explicitly state `Not run` and why).
 - Issues: include `Fixes #...` when applicable; omit the line otherwise.
 
+### 2.9 GitHub issue conventions (required)
+
+When filing an issue, optimize for fast, high-confidence triage.
+
+- Title: concise, specific, and action-oriented (avoid vague titles like “It doesn’t work”).
+- Problem statement: what you were trying to do and why.
+- Reproduction: numbered steps starting from a clean state; include minimal config/snippets when possible.
+- Expected vs actual: explicit “Expected:” and “Actual:” sections.
+- Evidence: exact error messages/stack traces; screenshots only when text is insufficient.
+- Environment (redact secrets):
+  - OS + version
+  - Node + pnpm versions
+  - Obsidian version (if plugin-related)
+  - AILSS package versions (plugin/mcp/indexer/core) and how installed (release vs local build)
+  - Relevant env vars (names + non-secret values), especially `AILSS_*` (never include tokens/keys)
+- Component tagging: clearly state which component(s) are involved (`indexer`, `mcp`, `plugin`, `core`, `docs`).
+- MCP HTTP issues: include HTTP status, endpoint/path, whether `Mcp-Session-Id` was present, and which `AILSS_MCP_HTTP_*` settings were used (token redacted).
+- Proposed solution (optional): if you have a hypothesis or fix direction, add it as a separate bullet list.
+- Security: if the issue involves secrets or an exploitable vulnerability, do **not** file a public issue; report privately.
+
 ---
 
 ## 3. Agent working rules: accuracy / scope

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Write tools are disabled by default and require `AILSS_ENABLE_WRITE_TOOLS=1`. Th
 ## Safety and costs
 
 - The MCP service binds to `127.0.0.1` and requires a bearer token.
+- The MCP HTTP server evicts sessions when `AILSS_MCP_HTTP_MAX_SESSIONS` is exceeded (default: 20; override by setting `AILSS_MCP_HTTP_MAX_SESSIONS=<n>`).
 - Index-time embeddings and query-time vectors (`get_context`) use the OpenAI embeddings API and can incur costs.
 - Metadata tools (`search_notes`, `list_tags`, `list_keywords`, typed-link graph/backrefs) are DB-only and do not call embeddings APIs.
 - Write tools are disabled by default and require both `AILSS_ENABLE_WRITE_TOOLS=1` and an explicit request with `apply=true`.

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -308,7 +308,7 @@ Status (implemented):
 
 - Implemented in `packages/mcp/src/httpServer.ts` using a session manager that creates one server + transport per `initialize`.
 - Defaults:
-  - `AILSS_MCP_HTTP_MAX_SESSIONS=10`
+  - `AILSS_MCP_HTTP_MAX_SESSIONS=20`
   - `AILSS_MCP_HTTP_IDLE_TTL_MS=3600000` (1 hour)
   - `AILSS_MCP_HTTP_SHUTDOWN_TOKEN=<token>` (optional; enables `POST /__ailss/shutdown`; use a separate admin token)
 

--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -176,9 +176,9 @@ function getSingleHeaderValue(req: IncomingMessage, name: string): string | null
 }
 
 function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "10").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "20").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 10;
+  if (!Number.isFinite(n) || n < 1) return 20;
   return n;
 }
 


### PR DESCRIPTION
## What

- Raise the default `AILSS_MCP_HTTP_MAX_SESSIONS` from 10 to 20.
- Add GitHub issue filing guidelines to `AGENTS.md`.

## Why

- Reduce unexpected session eviction when multiple MCP clients are connected.
- Improve issue reports to speed up triage.
- Fixes #25

## How

- Update the MCP HTTP server env parsing fallback default to 20.
- Update docs to reflect the new default and override behavior.
- Validation: `pnpm check`
