### PR TITLE
chore: revert PR #40 (MCP title)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,7 +6,7 @@ changelog:
     - title: Obsidian Plugin
       labels:
         - plugin
-    - title: MCP
+    - title: MCP Server
       labels:
         - mcp
     - title: Indexer CLI


### PR DESCRIPTION
Reverts PR #40 (commit ed2e83c) to restore main to the previous release-notes section title ('MCP Server').