### PR TITLE
chore: rename MCP Server section to MCP

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -6,7 +6,7 @@ changelog:
     - title: Obsidian Plugin
       labels:
         - plugin
-    - title: MCP Server
+    - title: MCP
       labels:
         - mcp
     - title: Indexer CLI


### PR DESCRIPTION
Changes the auto-generated Release notes category title from 'MCP Server' to 'MCP'.