### PR TITLE
docs: clarify PR/issue title conventions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,6 +7,8 @@ labels: ["bug"]
 
 Please include a minimal repro and relevant logs.
 Do not paste API keys or private note content.
+Please avoid adding component/scope to the title (no `bug(mcp): ...`, no `plugin: ...`).
+Use the component checklist below and labels instead.
 
 ## Component
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -8,6 +8,8 @@ body:
       value: |
         Please include a minimal repro and relevant logs.
         Do not paste API keys or private note content.
+        Please avoid adding component/scope to the title (no `bug(mcp): ...`, no `plugin: ...`).
+        Use the `Component` field below and labels instead.
 
   - type: dropdown
     id: component

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -5,6 +5,18 @@ title: "docs: "
 labels: ["documentation"]
 ---
 
+Please avoid adding component/scope to the title (no `docs(ops): ...`, no `mcp: ...`).
+Use labels and the component checklist below instead.
+
+## Component (optional)
+
+- [ ] Indexer (`packages/indexer`)
+- [ ] MCP server (`packages/mcp`)
+- [ ] Obsidian plugin (`packages/obsidian-plugin`)
+- [ ] Core/shared (`packages/core`)
+- [ ] Docs
+- [ ] Not sure
+
 ## Doc location
 
 Which doc needs updating?

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -6,16 +6,7 @@ labels: ["documentation"]
 ---
 
 Please avoid adding component/scope to the title (no `docs(ops): ...`, no `mcp: ...`).
-Use labels and the component checklist below instead.
-
-## Component (optional)
-
-- [ ] Indexer (`packages/indexer`)
-- [ ] MCP server (`packages/mcp`)
-- [ ] Obsidian plugin (`packages/obsidian-plugin`)
-- [ ] Core/shared (`packages/core`)
-- [ ] Docs
-- [ ] Not sure
+Use labels for component tagging instead.
 
 ## Doc location
 

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -3,6 +3,25 @@ description: Report missing/incorrect docs
 title: "docs: "
 labels: ["documentation"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please avoid adding component/scope to the title (no `docs(ops): ...`, no `mcp: ...`).
+        Use the `Component` field below and labels instead.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component (optional)
+      description: Which area is the doc about?
+      options:
+        - Indexer (packages/indexer)
+        - MCP server (packages/mcp)
+        - Obsidian plugin (packages/obsidian-plugin)
+        - Core/shared (packages/core)
+        - Docs
+        - Not sure
+
   - type: textarea
     id: location
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -7,20 +7,7 @@ body:
     attributes:
       value: |
         Please avoid adding component/scope to the title (no `docs(ops): ...`, no `mcp: ...`).
-        Use the `Component` field below and labels instead.
-
-  - type: dropdown
-    id: component
-    attributes:
-      label: Component (optional)
-      description: Which area is the doc about?
-      options:
-        - Indexer (packages/indexer)
-        - MCP server (packages/mcp)
-        - Obsidian plugin (packages/obsidian-plugin)
-        - Core/shared (packages/core)
-        - Docs
-        - Not sure
+        Use labels for component tagging instead.
 
   - type: textarea
     id: location

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -6,16 +6,7 @@ labels: ["enhancement"]
 ---
 
 Please avoid adding component/scope to the title (no `feat(mcp): ...`, no `plugin: ...`).
-Use labels and the component checklist below instead.
-
-## Component (optional)
-
-- [ ] Indexer (`packages/indexer`)
-- [ ] MCP server (`packages/mcp`)
-- [ ] Obsidian plugin (`packages/obsidian-plugin`)
-- [ ] Core/shared (`packages/core`)
-- [ ] Docs
-- [ ] Not sure
+Use labels for component tagging instead.
 
 ## Problem statement
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -5,6 +5,18 @@ title: "feat: "
 labels: ["enhancement"]
 ---
 
+Please avoid adding component/scope to the title (no `feat(mcp): ...`, no `plugin: ...`).
+Use labels and the component checklist below instead.
+
+## Component (optional)
+
+- [ ] Indexer (`packages/indexer`)
+- [ ] MCP server (`packages/mcp`)
+- [ ] Obsidian plugin (`packages/obsidian-plugin`)
+- [ ] Core/shared (`packages/core`)
+- [ ] Docs
+- [ ] Not sure
+
 ## Problem statement
 
 What problem are you trying to solve?

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -7,20 +7,7 @@ body:
     attributes:
       value: |
         Please avoid adding component/scope to the title (no `feat(mcp): ...`, no `plugin: ...`).
-        Use the `Component` field below and labels instead.
-
-  - type: dropdown
-    id: component
-    attributes:
-      label: Component (optional)
-      description: Where is the change happening?
-      options:
-        - Indexer (packages/indexer)
-        - MCP server (packages/mcp)
-        - Obsidian plugin (packages/obsidian-plugin)
-        - Core/shared (packages/core)
-        - Docs
-        - Not sure
+        Use labels for component tagging instead.
 
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,6 +3,25 @@ description: Suggest an improvement or new capability
 title: "feat: "
 labels: ["enhancement"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please avoid adding component/scope to the title (no `feat(mcp): ...`, no `plugin: ...`).
+        Use the `Component` field below and labels instead.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component (optional)
+      description: Where is the change happening?
+      options:
+        - Indexer (packages/indexer)
+        - MCP server (packages/mcp)
+        - Obsidian plugin (packages/obsidian-plugin)
+        - Core/shared (packages/core)
+        - Docs
+        - Not sure
+
   - type: textarea
     id: problem
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -5,6 +5,18 @@ title: "question: "
 labels: ["question"]
 ---
 
+Please avoid adding component/scope to the title (no `mcp: ...`, no `plugin: ...`).
+Use labels and the component checklist below instead.
+
+## Component (optional)
+
+- [ ] Indexer (`packages/indexer`)
+- [ ] MCP server (`packages/mcp`)
+- [ ] Obsidian plugin (`packages/obsidian-plugin`)
+- [ ] Core/shared (`packages/core`)
+- [ ] Docs
+- [ ] Not sure
+
 ## Your question
 
 What are you trying to do, and what’s blocking you?

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,16 +6,7 @@ labels: ["question"]
 ---
 
 Please avoid adding component/scope to the title (no `mcp: ...`, no `plugin: ...`).
-Use labels and the component checklist below instead.
-
-## Component (optional)
-
-- [ ] Indexer (`packages/indexer`)
-- [ ] MCP server (`packages/mcp`)
-- [ ] Obsidian plugin (`packages/obsidian-plugin`)
-- [ ] Core/shared (`packages/core`)
-- [ ] Docs
-- [ ] Not sure
+Use labels for component tagging instead.
 
 ## Your question
 

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,20 +7,7 @@ body:
     attributes:
       value: |
         Please avoid adding component/scope to the title (no `mcp: ...`, no `plugin: ...`).
-        Use the `Component` field below and labels instead.
-
-  - type: dropdown
-    id: component
-    attributes:
-      label: Component (optional)
-      description: Where is the question about?
-      options:
-        - Indexer (packages/indexer)
-        - MCP server (packages/mcp)
-        - Obsidian plugin (packages/obsidian-plugin)
-        - Core/shared (packages/core)
-        - Docs
-        - Not sure
+        Use labels for component tagging instead.
 
   - type: textarea
     id: question

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -3,6 +3,25 @@ description: Ask a question about setup, usage, or behavior
 title: "question: "
 labels: ["question"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Please avoid adding component/scope to the title (no `mcp: ...`, no `plugin: ...`).
+        Use the `Component` field below and labels instead.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component (optional)
+      description: Where is the question about?
+      options:
+        - Indexer (packages/indexer)
+        - MCP server (packages/mcp)
+        - Obsidian plugin (packages/obsidian-plugin)
+        - Core/shared (packages/core)
+        - Docs
+        - Not sure
+
   - type: textarea
     id: question
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,3 @@
 ## How
 
 - [REPLACE ME]
-
-## Testing
-
-- [REPLACE ME] (exact commands, or `Not run: <reason>`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,17 @@
 ## What
 
-[REPLACE ME]
+- [REPLACE ME]
 
 ## Why
 
-[REPLACE ME]
+- [REPLACE ME]
 
 - Fixes #<issue-number> (optional; delete if not applicable)
 
 ## How
 
-[REPLACE ME]
+- [REPLACE ME]
+
+## Testing
+
+- [REPLACE ME] (exact commands, or `Not run: <reason>`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ When filing an issue, optimize for fast, high-confidence triage.
 
 - Title: concise, specific, and action-oriented (avoid vague titles like “It doesn’t work”).
 - Prefer using the Issue templates under `.github/ISSUE_TEMPLATE/` (they standardize title prefixes and required fields).
-- Avoid encoding component or scope in the title (no `type(scope): ...` and no `component: ...` prefixes); use labels and template fields (e.g. `Component`) instead.
+- Avoid encoding component or scope in the title (no `type(scope): ...` and no `component: ...` prefixes); use labels (and template fields when present) instead.
 - Problem statement: what you were trying to do and why.
 - Reproduction: numbered steps starting from a clean state; include minimal config/snippets when possible.
 - Expected vs actual: explicit “Expected:” and “Actual:” sections.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ This repo recommends Conventional Commits.
 - Title format: `<type>: <title>`
   - Allowed `type`: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `build`, `ci`, `perf`, `revert`
   - `<title>` must start with a lowercase letter (e.g. `feat: add ...`, not `feat: Add ...`)
+  - Do not use Conventional Commit scopes in PR titles (no `type(scope): ...`) — scopes are for commit messages only.
 - Body: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
 - Language: PR title and body must be written in English.
 - Sections: for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,8 @@ This repo recommends Conventional Commits.
 When filing an issue, optimize for fast, high-confidence triage.
 
 - Title: concise, specific, and action-oriented (avoid vague titles like “It doesn’t work”).
+- Prefer using the Issue templates under `.github/ISSUE_TEMPLATE/` (they standardize title prefixes and required fields).
+- Avoid encoding component or scope in the title (no `type(scope): ...` and no `component: ...` prefixes); use labels and template fields (e.g. `Component`) instead.
 - Problem statement: what you were trying to do and why.
 - Reproduction: numbered steps starting from a clean state; include minimal config/snippets when possible.
 - Expected vs actual: explicit “Expected:” and “Actual:” sections.

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -16,6 +16,11 @@ We follow Conventional Commits and standardize on:
 <type>(<scope>): <subject>
 ```
 
+Note:
+
+- This format is for **commit messages**.
+- Pull Request titles use `<type>: <title>` (no scope); see `AGENTS.md`.
+
 Examples:
 
 - `feat(monorepo): scaffold core/db + indexer + mcp stdio`


### PR DESCRIPTION
## What

- Clarify PR title format (`<type>: <title>`) and discourage `type(scope): ...` in PR titles
- Keep the PR template bullet-only (no dedicated `## Testing` section)
- Discourage component/scope prefixes in issue titles while relying on labels for component tagging
- Clarify in commit conventions docs that scopes apply to commit messages (not PR titles)

## Why

- Prevent mixed title formats across PRs and issues
- Reduce confusion between commit message scopes and PR/issue title conventions
- Keep titles concise while using labels for component tagging

## How

- Update `AGENTS.md` rules for PR titles and issue titles
- Update `.github/pull_request_template.md`
- Update `.github/ISSUE_TEMPLATE/*`
- Update `docs/standards/commits.md`
- Testing: `pnpm check`
