### PR TITLE
docs: generalize prompts and skill section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,17 @@ Set `AILSS_MCP_BEARER_TOKEN` to the token from step 3.
 ## How it works
 
 AILSS writes a local index DB at `<vault>/.ailss/index.sqlite` and serves retrieval over an MCP endpoint hosted by the Obsidian plugin.
+
 This setup lets Codex connect over HTTP without needing direct vault filesystem permissions.
 
 ## Vault model
 
 AILSS treats your vault as a knowledge graph:
 
-- YAML frontmatter: structured note metadata. Required keys: `id` (`YYYYMMDDHHmmss`, derived from `created`), `created`, `title`, `summary`, `aliases`, `entity`, `layer`, `tags`, `keywords`, `status`, `updated`, `source`.
-- Typed links: frontmatter keys of wikilinks for semantic relations (graph edges). Common keys: `instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `authored_by`, `same_as`, `supersedes`.
+- YAML frontmatter: structured note metadata.
+  - Required keys: `id` (`YYYYMMDDHHmmss`, derived from `created`), `created`, `title`, `summary`, `aliases`, `entity`, `layer`, `tags`, `keywords`, `status`, `updated`, `source`.
+- Typed links: frontmatter keys of wikilinks for semantic relations (graph edges).
+  - Common keys: `instance_of`, `part_of`, `depends_on`, `uses`, `implements`, `cites`, `authored_by`, `same_as`, `supersedes`.
 
 Full rules: `docs/standards/vault/README.md`.
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ http_headers = { Authorization = "Bearer <token>" }
 
 Set `AILSS_MCP_BEARER_TOKEN` to the token from step 3.
 
-## Prompts and Codex skill
+## Prompts and Skill
 
 - Vault prompt: use **Prompt installer (vault root)** to write `AGENTS.md` at your vault root.
-- Codex skill: use **Copy Prometheus Agent skill (Codex)** and install `~/.codex/skills/ailss-prometheus-agent/SKILL.md`.
+- Agent Skill: use **Copy Prometheus Agent Skill** and install it in your terminal AI client’s skill directory (for example, Codex CLI uses `~/.codex/skills/ailss-prometheus-agent/SKILL.md`).
 
 ## How it works
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,11 +3,11 @@ pre-commit:
   commands:
     prettier:
       glob: "*.{ts,tsx,js,cjs,mjs,json,md,yml,yaml}"
-      run: pnpm prettier --write {staged_files}
+      run: pnpm exec prettier --write {staged_files}
       stage_fixed: true
     eslint:
       glob: "*.{ts,tsx}"
-      run: pnpm eslint --fix {staged_files}
+      run: pnpm exec eslint --fix {staged_files}
       stage_fixed: true
 
 commit-msg:


### PR DESCRIPTION
## What

- Generalize README "Prompts and Skill" guidance to be terminal AI client-agnostic (Codex path kept as an example).
- Improve README "Vault model" list formatting for readability.
- Fix lefthook pre-commit commands to run Prettier/Eslint via `pnpm exec` (unblocks commits).

## Why

- The README previously implied a Codex-only setup, but the prompt/skill concepts apply to other terminal AI clients too.
- The pre-commit hook was calling `pnpm prettier` / `pnpm eslint` even though no such scripts exist, causing commits to fail.

## How

- Update `lefthook.yml` to use `pnpm exec prettier` and `pnpm exec eslint`.
- Update `README.md` section header and bullet wording; keep Codex CLI as an example path.
- Reformat the Vault model bullets without changing meaning.
- Validation: `pnpm check`
