### PR TITLE
fix: prevent idle session self-eviction

### DIFF
--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -369,8 +369,6 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
         return;
       }
 
-      closeIdleSessions(sessions, idleTtlMs);
-
       let parsedBody: unknown = undefined;
       if (req.method === "POST") {
         try {
@@ -383,6 +381,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
       }
 
       if (req.method === "POST" && isInitializeRequestMessage(parsedBody)) {
+        closeIdleSessions(sessions, idleTtlMs);
         const { server, transport } = await createSession(runtime, sessions, maxSessions);
         await transport.handleRequest(
           req as IncomingMessage & { auth?: AuthInfo },
@@ -420,6 +419,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
       }
 
       session.lastSeenAtMs = Date.now();
+      closeIdleSessions(sessions, idleTtlMs);
       await session.transport.handleRequest(
         req as IncomingMessage & { auth?: AuthInfo },
         res,


### PR DESCRIPTION
## What
- Prevents the active `mcp-session-id` from being evicted by idle session cleanup during request handling.
- Updates session lifecycle tests to cover idle eviction ordering and long-idle reuse.

## Why
- Codex CLI can stay idle for long periods; subsequent MCP calls can fail with `Session not found` (404) even though the client still holds a session id.
- Fixes #47.

## How
- Run idle session cleanup (`closeIdleSessions`) after the current session is looked up and its `lastSeenAtMs` is refreshed.
- Extend `httpSessions.sessionLifecycle` tests to assert:
  - idle sessions are evicted when another active session makes a request
  - the active session is not evicted on the first request after a long idle
- Validation:
  - `pnpm build`
  - `pnpm check`
