### PR TITLE
feat: rename typed link tools with explicit direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Full rules: `docs/standards/vault/README.md`.
 
 Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 
-- Read tools: `get_context`, `get_typed_links`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_link_backrefs`
+- Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`
 - Write tools (gated): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`  
   Requires `AILSS_ENABLE_WRITE_TOOLS=1` and `apply=true`.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -32,8 +32,8 @@ Read-first tools (implemented in this repo):
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
   - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
   - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000)
-- `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
-- `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges)
+- `expand_typed_links_outgoing`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
+- `find_typed_links_incoming`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)
 - `read_note`: read a vault note by path → return raw note text (may be truncated; requires `AILSS_VAULT_PATH`)
 - `get_vault_tree`: folder tree view of vault markdown files (filesystem-backed)
@@ -63,7 +63,7 @@ Frontmatter query support (current):
 - AILSS stores normalized frontmatter in SQLite for retrieval and graph building.
 - The MCP surface supports both:
   - semantic retrieval via `get_context`
-  - metadata filtering via `search_notes` + typed-link navigation/backrefs via `get_typed_links` / `find_typed_link_backrefs`
+  - metadata filtering via `search_notes` + typed-link navigation/backrefs via `expand_typed_links_outgoing` / `find_typed_links_incoming`
 
 Read-first tools (planned):
 

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,7 +24,7 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-  - Read-first tools: `get_context`, `get_typed_links`, `find_typed_link_backrefs`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+  - Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
   - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
@@ -49,7 +49,7 @@ It also records a few **hard decisions** so code and docs stay consistent.
 ## 3) MCP server MVP
 
 - Provide `get_context` (semantic retrieval) + `read_note` (exact note text)
-- Provide `get_typed_links` for typed-link navigation from a note path (outgoing only; bounded graph)
+- Provide `expand_typed_links_outgoing` for typed-link navigation from a note path (outgoing only; bounded graph)
 - Include enough evidence in results (note path + snippet + optional preview)
 
 ## 4) Obsidian plugin MVP
@@ -120,8 +120,8 @@ MCP tools (read-only):
 Implemented:
 
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
-- `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
-- `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges)
+- `expand_typed_links_outgoing`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
+- `find_typed_links_incoming`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)
 - `read_note`: read a vault note by path → return raw note text (may be truncated; requires `AILSS_VAULT_PATH`)
 - `get_vault_tree`: folder tree view of vault markdown files (filesystem-backed; requires `AILSS_VAULT_PATH`)
@@ -134,7 +134,7 @@ Implemented:
 Notes on queryability (current):
 
 - AILSS stores normalized frontmatter + typed links in SQLite (used for graph expansion and retrieval).
-- The MCP surface supports both semantic retrieval (`get_context`) and structured navigation/filtering (`get_typed_links`, `find_typed_link_backrefs`, `search_notes`).
+- The MCP surface supports both semantic retrieval (`get_context`) and structured navigation/filtering (`expand_typed_links_outgoing`, `find_typed_links_incoming`, `search_notes`).
 - Frontmatter normalization coerces YAML-inferred scalars (unquoted numbers/dates) to strings for core identity fields (`id`, `created`, `updated`) so existing vault notes can remain unquoted.
 
 Planned:

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -4,13 +4,13 @@ description: "Obsidian vault notes (AILSS): search/summarize/edit (frontmatter, 
 mcp_tools:
   # Always available (read tools)
   - get_context
-  - get_typed_links
+  - expand_typed_links_outgoing
   - resolve_note
   - read_note
   - get_vault_tree
   - frontmatter_validate
   - find_broken_links
-  - find_typed_link_backrefs
+  - find_typed_links_incoming
   - search_notes
   - list_tags
   - list_keywords
@@ -28,7 +28,7 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 ## Core workflow
 
 1. Start with `get_context` for the user’s query (avoid guessing and avoid duplicates).
-2. Use `get_typed_links` to navigate the semantic graph from a specific note (DB-backed).
+2. Use `expand_typed_links_outgoing` to navigate the semantic graph from a specific note (DB-backed).
    - Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements; do not add reciprocal links unless explicitly requested.
 3. Use `resolve_note` when you only have `id`/`title`/a wikilink target and need a vault-relative path for `read_note`/`edit_note`.
 4. Use `read_note` to confirm exact wording and frontmatter before making claims.
@@ -54,7 +54,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
   - `read_note` is path-based. If you only have `id`/`title`/a wikilink target, call `resolve_note` first.
 - For metadata filtering (entity/layer/status/tags/keywords/source/date ranges), use `search_notes` (DB-only; no embeddings).
 - Before adding new tags/keywords, prefer reusing existing vocabulary via `list_tags` / `list_keywords`.
-- If you need typed-link navigation starting from a specific note path, call `get_typed_links` (outgoing only; bounded graph).
+- If you need typed-link navigation starting from a specific note path, call `expand_typed_links_outgoing` (outgoing only; bounded graph).
 - Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements; do not add reciprocal links unless explicitly requested.
 - If you are unsure what tools exist or what arguments they require, call `tools/list` and follow the returned schemas exactly.
 
@@ -63,7 +63,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
 - Use `get_vault_tree` when you need a filesystem folder tree for the vault.
 - Use `frontmatter_validate` when you need to audit frontmatter health (required keys + `id`/`created` consistency).
 - Use `find_broken_links` when you need to detect unresolved wikilinks/typed links after moves/renames.
-- Use `find_typed_link_backrefs` when you need incoming edges/backrefs for a target.
+- Use `find_typed_links_incoming` when you need incoming edges/backrefs for a target.
 
 ### Safe edits (explicit apply only)
 

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -73,7 +73,7 @@ Before wiring the MCP server into Codex CLI or the Obsidian plugin, it can be us
 
 Notes:
 
-- The inspector will launch the STDIO server command you provide and let you call tools like `get_context` and `get_typed_links`.
+- The inspector will launch the STDIO server command you provide and let you call tools like `get_context` and `expand_typed_links_outgoing`.
 - For write tools (e.g. `edit_note`), prefer `apply=false` first and only confirm/apply when you are sure the target path and patch ops are correct.
 
 Example:

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -14,7 +14,7 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `top_k` (int, default: `10`, range: `1–50`)
   - `max_chars_per_note` (int, default: `2000`, range: `200–50,000`)
 
-### `get_typed_links`
+### `expand_typed_links_outgoing`
 
 - Purpose: expand outgoing typed links into a bounded metadata graph (DB-only).
 - Input:
@@ -31,7 +31,7 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `query` (string, required)
   - `limit` (int, default: `20`, range: `1–200`)
 
-### `find_typed_link_backrefs`
+### `find_typed_links_incoming`
 
 - Purpose: find incoming typed links pointing to a target (DB-only).
 - Input:

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -27,13 +27,13 @@ Global working rules for the AILSS Obsidian vault.
   - Use read-first by default. Writes require explicit `apply=true`.
     - Default policy: do `apply=false` preview first, then proceed with `apply=true` automatically for `capture_note` / `edit_note` / `improve_frontmatter` (auto-apply).
   - Leading queries: `get_context` (semantic retrieval), `get_vault_tree` (folder/file structure)
-  - Follow-up queries: `read_note` (exact text + frontmatter), `get_typed_links` (typed-link graph)
+  - Follow-up queries: `read_note` (exact text + frontmatter), `expand_typed_links_outgoing` (typed-link graph)
 - Recommended flow:
   1. Use `get_context` to collect candidate notes (write your query as a full sentence for reproducibility).
   2. Use `read_note` to confirm exact wording and frontmatter.
      - Note: `read_note` does **not** search by title/id; it reads by vault-relative `path`.
      - If you only know `id`/`title`, use `resolve_note` (preferred) or `search_notes` to find candidate paths first, then `read_note`.
-  3. Use `get_typed_links` (outgoing only) to check for missing relationships and navigation gaps.
+  3. Use `expand_typed_links_outgoing` (outgoing only) to check for missing relationships and navigation gaps.
   4. Use the typed-links coverage checklist (see `./typed-links.md`) to fill obvious omissions.
   5. Use `edit_note` for edits and `relocate_note` for moves/renames (`relocate_note` is still manual confirm; `edit_note` is auto-apply).
 - Failure handling: record the error and cause; temporarily fall back to `rg`/`find` only if MCP calls fail.
@@ -46,8 +46,8 @@ Global working rules for the AILSS Obsidian vault.
 - `search_notes`: DB-backed metadata filtering (frontmatter-derived fields, tags/keywords/sources); no embeddings calls.
 - `list_tags`: list indexed tags and counts (use to reuse existing vocabulary).
 - `list_keywords`: list indexed keywords and counts (use to reuse existing vocabulary).
-- `get_typed_links`: expands outgoing typed links into a bounded graph (metadata only).
-- `find_typed_link_backrefs`: find notes that link _to_ a target via typed links (incoming edges).
+- `expand_typed_links_outgoing`: expands outgoing typed links into a bounded graph (metadata only).
+- `find_typed_links_incoming`: find notes that link _to_ a target via typed links (incoming edges).
 - `get_vault_tree`: returns a folder/file tree for vault Markdown files.
 - `frontmatter_validate`: validates vault-wide frontmatter key presence + `id`/`created` consistency.
 - `find_broken_links`: detects unresolved wikilinks/typed links by resolving targets against indexed notes.

--- a/docs/standards/vault/typed-links.md
+++ b/docs/standards/vault/typed-links.md
@@ -38,7 +38,7 @@ Notes:
 ### How AILSS uses typed links (implementation notes)
 
 - Typed links are extracted from frontmatter into a structured edge list (stored as `typed_links` in the index DB).
-- The `get_typed_links` tool reads those edges and expands outgoing links into a bounded graph (metadata only).
+- The `expand_typed_links_outgoing` tool reads those edges and expands outgoing links into a bounded graph (metadata only).
 
 ### Workflow: derive relationships from semantic analysis
 

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -8,13 +8,13 @@ import { embeddingDimForModel } from "./lib/openaiEmbeddings.js";
 import type { McpToolDeps } from "./mcpDeps.js";
 import { registerCaptureNoteTool } from "./tools/captureNote.js";
 import { registerEditNoteTool } from "./tools/editNote.js";
-import { registerFindTypedLinkBackrefsTool } from "./tools/findTypedLinkBackrefs.js";
+import { registerExpandTypedLinksOutgoingTool } from "./tools/expandTypedLinksOutgoing.js";
 import { registerFindBrokenLinksTool } from "./tools/findBrokenLinks.js";
+import { registerFindTypedLinksIncomingTool } from "./tools/findTypedLinksIncoming.js";
 import { registerFrontmatterValidateTool } from "./tools/frontmatterValidate.js";
 import { registerGetContextTool } from "./tools/getContext.js";
 import { registerGetNoteTool } from "./tools/getNote.js";
 import { registerGetVaultTreeTool } from "./tools/getVaultTree.js";
-import { registerGetTypedLinksTool } from "./tools/getTypedLinks.js";
 import { registerImproveFrontmatterTool } from "./tools/improveFrontmatter.js";
 import { registerListKeywordsTool } from "./tools/listKeywords.js";
 import { registerListTagsTool } from "./tools/listTags.js";
@@ -69,7 +69,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   const server = new McpServer({ name: "ailss-mcp", version: "0.1.0" });
 
   registerGetContextTool(server, deps);
-  registerGetTypedLinksTool(server, deps);
+  registerExpandTypedLinksOutgoingTool(server, deps);
   registerResolveNoteTool(server, deps);
   registerGetNoteTool(server, deps);
   registerGetVaultTreeTool(server, deps);
@@ -78,7 +78,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   registerSearchNotesTool(server, deps);
   registerListTagsTool(server, deps);
   registerListKeywordsTool(server, deps);
-  registerFindTypedLinkBackrefsTool(server, deps);
+  registerFindTypedLinksIncomingTool(server, deps);
 
   if (runtime.enableWriteTools) {
     registerCaptureNoteTool(server, deps);

--- a/packages/mcp/src/tools/expandTypedLinksOutgoing.ts
+++ b/packages/mcp/src/tools/expandTypedLinksOutgoing.ts
@@ -1,4 +1,4 @@
-// get_typed_links tool
+// expand_typed_links_outgoing tool
 // - DB-backed typed-link expansion (outgoing only; depth-unbounded, bounded by max_notes/max_edges)
 
 import { getNoteMeta, resolveNotePathsByWikilinkTarget } from "@ailss/core";
@@ -7,11 +7,11 @@ import { z } from "zod";
 
 import type { McpToolDeps } from "../mcpDeps.js";
 
-export function registerGetTypedLinksTool(server: McpServer, deps: McpToolDeps): void {
+export function registerExpandTypedLinksOutgoingTool(server: McpServer, deps: McpToolDeps): void {
   server.registerTool(
-    "get_typed_links",
+    "expand_typed_links_outgoing",
     {
-      title: "Get typed links",
+      title: "Expand typed links outgoing",
       description:
         "Expands outgoing typed links from a specified note path into a bounded graph of note metadata (DB-only; no note body reads). Traversal continues until no more nodes are found or safety bounds are hit.",
       inputSchema: {

--- a/packages/mcp/src/tools/findTypedLinksIncoming.ts
+++ b/packages/mcp/src/tools/findTypedLinksIncoming.ts
@@ -1,4 +1,4 @@
-// find_typed_link_backrefs tool
+// find_typed_links_incoming tool
 // - DB-backed typed-link backref queries (incoming edges)
 
 import { findNotesByTypedLink } from "@ailss/core";
@@ -7,11 +7,11 @@ import { z } from "zod";
 
 import type { McpToolDeps } from "../mcpDeps.js";
 
-export function registerFindTypedLinkBackrefsTool(server: McpServer, deps: McpToolDeps): void {
+export function registerFindTypedLinksIncomingTool(server: McpServer, deps: McpToolDeps): void {
   server.registerTool(
-    "find_typed_link_backrefs",
+    "find_typed_links_incoming",
     {
-      title: "Find typed link backrefs",
+      title: "Find typed links incoming",
       description:
         "Finds notes that reference a target via typed links. This is an incoming-edge query over the typed_links table.",
       inputSchema: {

--- a/packages/mcp/test/httpTools.findTypedLinksIncoming.test.ts
+++ b/packages/mcp/test/httpTools.findTypedLinksIncoming.test.ts
@@ -12,8 +12,8 @@ import {
   withTempDir,
 } from "./httpTestUtils.js";
 
-describe("MCP HTTP server (get_typed_links)", () => {
-  it("returns typed links via get_typed_links", async () => {
+describe("MCP HTTP server (find_typed_links_incoming)", () => {
+  it("returns typed link backrefs via find_typed_links_incoming", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");
 
@@ -33,7 +33,7 @@ describe("MCP HTTP server (get_typed_links)", () => {
           );
 
           fileStmt.run("A.md", 0, 0, "0", now);
-          fileStmt.run("B.md", 0, 0, "0", now);
+          fileStmt.run("WorldAce.md", 0, 0, "0", now);
 
           noteStmt.run(
             "A.md",
@@ -49,45 +49,35 @@ describe("MCP HTTP server (get_typed_links)", () => {
             now,
           );
           noteStmt.run(
-            "B.md",
-            "B",
+            "WorldAce.md",
+            "WorldAce",
             now,
-            "B",
+            "WorldAce",
             null,
             null,
             "conceptual",
             "draft",
             now,
-            JSON.stringify({ id: "B", title: "B", tags: [] }),
+            JSON.stringify({ id: "WorldAce", title: "WorldAce", tags: [] }),
             now,
           );
 
-          linkStmt.run("A.md", "cites", "B", "[[B]]", 0, now);
+          linkStmt.run("A.md", "part_of", "WorldAce", "[[WorldAce]]", 0, now);
 
           const sessionId = await mcpInitialize(url, token, "client-a");
-          const res = await mcpToolsCall(url, token, sessionId, "get_typed_links", {
-            path: "A.md",
-            max_notes: 10,
-            max_edges: 10,
-            max_resolutions_per_target: 5,
+          const res = await mcpToolsCall(url, token, sessionId, "find_typed_links_incoming", {
+            rel: "part_of",
+            to_target: "WorldAce",
+            limit: 10,
           });
 
           const structured = getStructuredContent(res);
-
-          const nodes = structured["nodes"];
-          assertArray(nodes, "nodes");
-          expect(nodes.map((n) => (n as Record<string, unknown>)["path"]).sort()).toEqual([
-            "A.md",
-            "B.md",
-          ]);
-
-          const edges = structured["edges"];
-          assertArray(edges, "edges");
-          expect(edges.length).toBe(1);
-          assertRecord(edges[0], "edges[0]");
-          expect(edges[0]["direction"]).toBe("outgoing");
-          expect(edges[0]["from_path"]).toBe("A.md");
-          expect(edges[0]["to_path"]).toBe("B.md");
+          const backrefs = structured["backrefs"];
+          assertArray(backrefs, "backrefs");
+          expect(backrefs).toHaveLength(1);
+          assertRecord(backrefs[0], "backrefs[0]");
+          expect(backrefs[0]["from_path"]).toBe("A.md");
+          expect(backrefs[0]["to_target"]).toBe("WorldAce");
         },
       );
     });


### PR DESCRIPTION
## What

- Rename typed-link MCP tools to make direction explicit:
  - `get_typed_links` -> `expand_typed_links_outgoing`
  - `find_typed_link_backrefs` -> `find_typed_links_incoming`
- Rename corresponding tool implementation/test files to match the new names.
- Update all in-repo references (README, docs, and Codex skill metadata) to the new tool names.

## Why

- Tool names should communicate edge direction at a glance to reduce misuse and prompt confusion.
- This is an intentional breaking change to keep the tool surface explicit and consistent.
- Fixes #37

## How

- Update MCP server registration/imports to register the renamed tools.
- Update tool IDs in MCP handlers and tool-specific tests.
- Run validation:
  - `pnpm check`
