### PR TITLE
feat: treat ambiguous typed-link targets as broken in find_broken_links

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -68,8 +68,9 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 
 ### `find_broken_links`
 
-- Purpose: detect unresolved typed links / wikilinks via the `typed_links` table (DB-only).
+- Purpose: detect unresolved (and optionally ambiguous) typed links / wikilinks via the `typed_links` table (DB-only).
 - Input:
+  - `treat_ambiguous_as_broken` (boolean, default: `true`)
   - `path_prefix` (string, optional)
   - `rels` (string[], optional; default: typed-link keys)
   - `max_links` (int, default: `20000`, range: `1–100,000`)

--- a/packages/mcp/test/httpTools.findBrokenLinks.test.ts
+++ b/packages/mcp/test/httpTools.findBrokenLinks.test.ts
@@ -93,4 +93,130 @@ describe("MCP HTTP server (find_broken_links)", () => {
       );
     });
   });
+
+  it("treats ambiguous targets as broken when enabled", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer(
+        { dbPath, enableWriteTools: false },
+        async ({ url, token, runtime }) => {
+          const now = new Date().toISOString().slice(0, 19);
+
+          const fileStmt = runtime.deps.db.prepare(
+            "INSERT INTO files(path, mtime_ms, size_bytes, sha256, updated_at) VALUES (?, ?, ?, ?, ?)",
+          );
+          const noteStmt = runtime.deps.db.prepare(
+            "INSERT INTO notes(path, note_id, created, title, summary, entity, layer, status, updated, frontmatter_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          );
+          const linkStmt = runtime.deps.db.prepare(
+            "INSERT INTO typed_links(from_path, rel, to_target, to_wikilink, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+          );
+
+          fileStmt.run("A.md", 0, 0, "0", now);
+          fileStmt.run("B.md", 0, 0, "0", now);
+          fileStmt.run("sub/B.md", 0, 0, "0", now);
+
+          noteStmt.run(
+            "A.md",
+            "A",
+            now,
+            "A",
+            null,
+            null,
+            "conceptual",
+            "draft",
+            now,
+            JSON.stringify({ id: "A", title: "A", tags: [] }),
+            now,
+          );
+          noteStmt.run(
+            "B.md",
+            "B1",
+            now,
+            "B",
+            null,
+            null,
+            "conceptual",
+            "draft",
+            now,
+            JSON.stringify({ id: "B1", title: "B", tags: [] }),
+            now,
+          );
+          noteStmt.run(
+            "sub/B.md",
+            "B2",
+            now,
+            "B",
+            null,
+            null,
+            "conceptual",
+            "draft",
+            now,
+            JSON.stringify({ id: "B2", title: "B", tags: [] }),
+            now,
+          );
+
+          // One ambiguous typed link and one missing target.
+          linkStmt.run("A.md", "depends_on", "B", "[[B]]", 0, now);
+          linkStmt.run("A.md", "depends_on", "Missing", "[[Missing]]", 1, now);
+
+          const sessionId = await mcpInitialize(url, token, "client-a");
+
+          const defaultRes = await mcpToolsCall(url, token, sessionId, "find_broken_links", {
+            path_prefix: "A",
+            max_links: 100,
+            max_broken: 100,
+            max_resolutions_per_target: 5,
+          });
+
+          const defaultStructured = getStructuredContent(defaultRes);
+          expect(defaultStructured["scanned_links"]).toBe(2);
+          expect(defaultStructured["broken_total"]).toBe(2);
+
+          const defaultBroken = defaultStructured["broken"];
+          assertArray(defaultBroken, "broken");
+          expect(defaultBroken).toHaveLength(2);
+
+          const ambiguous = defaultBroken.find((b) => {
+            assertRecord(b, "broken[i]");
+            return String(b["target"] ?? "") === "B";
+          });
+          expect(ambiguous).toBeTruthy();
+          assertRecord(ambiguous, "ambiguous");
+          assertArray(ambiguous["resolutions"], "ambiguous.resolutions");
+
+          const resolutionPaths = ambiguous["resolutions"]
+            .map((r) => {
+              assertRecord(r, "resolutions[i]");
+              return String(r["path"] ?? "");
+            })
+            .sort();
+          expect(resolutionPaths).toEqual(["B.md", "sub/B.md"]);
+
+          const disabledRes = await mcpToolsCall(url, token, sessionId, "find_broken_links", {
+            path_prefix: "A",
+            max_links: 100,
+            max_broken: 100,
+            max_resolutions_per_target: 5,
+            treat_ambiguous_as_broken: false,
+          });
+
+          const disabledStructured = getStructuredContent(disabledRes);
+          expect(disabledStructured["scanned_links"]).toBe(2);
+          expect(disabledStructured["broken_total"]).toBe(1);
+
+          const disabledBroken = disabledStructured["broken"];
+          assertArray(disabledBroken, "broken");
+          const disabledTargets = disabledBroken
+            .map((b) => {
+              assertRecord(b, "broken[i]");
+              return String(b["target"] ?? "");
+            })
+            .sort();
+          expect(disabledTargets).toEqual(["Missing"]);
+        },
+      );
+    });
+  });
 });


### PR DESCRIPTION
## What

- Add `treat_ambiguous_as_broken` to `find_broken_links` (default `true`).
- Treat ambiguous targets (2+ resolutions) as broken and return candidate `resolutions[]` (capped by `max_resolutions_per_target`).
- Add an HTTP test covering ambiguous targets vs flag disabled.

## Why

- Make typed-link hygiene actionable by surfacing ambiguous targets during audits.
- Fixes #55

## How

- Extend tool input schema and broken-detection logic in `packages/mcp/src/tools/findBrokenLinks.ts`.
- Add a synthetic DB fixture with two matching notes and assert returned `resolutions[]`.
- Update `docs/reference/mcp-tools.md`.
- Testing: `pnpm build`, `pnpm test`
