### PR TITLE
feat: stitch evidence in get_context

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -29,9 +29,10 @@ Example tools:
 
 Read-first tools (implemented in this repo):
 
-- `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
+- `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with note metadata and stitched evidence chunks
   - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
-  - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000)
+  - Returns note metadata + stitched evidence chunks by default (file-start previews are disabled unless explicitly enabled)
+  - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000; used for file-start previews when enabled)
 - `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)

--- a/docs/architecture/data-db.md
+++ b/docs/architecture/data-db.md
@@ -23,6 +23,7 @@ Stores chunk-level text and metadata.
 
 - `chunk_id` (PK)
 - `path` (FK → `files.path`)
+- `chunk_index` (0-based order within the file)
 - `heading`, `heading_path_json`
 - `content`, `content_sha256`
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -8,11 +8,16 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 
 ### `get_context`
 
-- Purpose: semantic retrieval over the index DB (note previews when `AILSS_VAULT_PATH` is set).
+- Purpose: semantic retrieval over the index DB (returns note metadata + stitched evidence chunks; optional file-start previews).
 - Input:
   - `query` (string, required)
   - `top_k` (int, default: `10`, range: `1–50`)
-  - `max_chars_per_note` (int, default: `2000`, range: `200–50,000`)
+  - `expand_top_k` (int, default: `5`, range: `0–50`) — how many of the top_k notes include stitched evidence text
+  - `hit_chunks_per_note` (int, default: `2`, range: `1–5`)
+  - `neighbor_window` (int, default: `1`, range: `0–3`) — stitches ±window around the best hit
+  - `max_evidence_chars_per_note` (int, default: `1500`, range: `200–20,000`)
+  - `include_file_preview` (boolean, default: `false`) — when true, includes file-start preview (requires `AILSS_VAULT_PATH`)
+  - `max_chars_per_note` (int, default: `800`, range: `200–50,000`) — file-start preview size when `include_file_preview=true`
 
 ### `get_typed_links`
 

--- a/packages/core/src/indexing/indexVault.ts
+++ b/packages/core/src/indexing/indexVault.ts
@@ -75,6 +75,7 @@ type PlannedChunk = {
   chunkId: string;
   content: string;
   contentSha256: string;
+  chunkIndex: number;
   heading: string | null;
   headingPathJson: string;
 };
@@ -85,7 +86,7 @@ function computeStableChunkIds(fileRelPath: string, chunks: MarkdownChunk[]): Pl
   // - include an occurrence index to disambiguate duplicates within the same file
   const occurrenceByContent = new Map<string, number>();
 
-  return chunks.map((chunk) => {
+  return chunks.map((chunk, chunkIndex) => {
     const contentKey = chunk.contentSha256;
     const occurrence = occurrenceByContent.get(contentKey) ?? 0;
     occurrenceByContent.set(contentKey, occurrence + 1);
@@ -95,6 +96,7 @@ function computeStableChunkIds(fileRelPath: string, chunks: MarkdownChunk[]): Pl
       chunkId,
       content: chunk.content,
       contentSha256: chunk.contentSha256,
+      chunkIndex,
       heading: chunk.heading,
       headingPathJson: JSON.stringify(chunk.headingPath),
     };
@@ -271,6 +273,7 @@ export async function indexVault(options: IndexVaultOptions): Promise<IndexVault
       updateChunkMetadata(options.db, {
         chunkId: planned.chunkId,
         path: file.relPath,
+        chunkIndex: planned.chunkIndex,
         heading: planned.heading,
         headingPathJson: planned.headingPathJson,
         content: planned.content,
@@ -291,6 +294,7 @@ export async function indexVault(options: IndexVaultOptions): Promise<IndexVault
       insertChunkWithEmbedding(options.db, {
         chunkId: planned.chunkId,
         path: file.relPath,
+        chunkIndex: planned.chunkIndex,
         heading: planned.heading,
         headingPathJson: planned.headingPathJson,
         content: planned.content,

--- a/packages/core/src/vault/markdown.ts
+++ b/packages/core/src/vault/markdown.ts
@@ -121,7 +121,7 @@ export function chunkMarkdownByHeadings(
           heading: headingText,
           headingDepth: depth,
           headingPath: nextPath,
-          buffer: [],
+          buffer: [line],
         };
         continue;
       }

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -49,6 +49,7 @@ describe("openAilssDb() + semanticSearch()", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "chunk-1",
         path: "notes/a.md",
+        chunkIndex: 0,
         heading: "A",
         headingPathJson: JSON.stringify(["A"]),
         content: "hello world",
@@ -82,6 +83,7 @@ describe("openAilssDb() + semanticSearch()", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "chunk-1",
         path: "notes/a.md",
+        chunkIndex: 0,
         heading: "A",
         headingPathJson: JSON.stringify(["A"]),
         content: "hello world",
@@ -114,6 +116,7 @@ describe("openAilssDb() + semanticSearch()", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "chunk-1",
         path: "notes/a.md",
+        chunkIndex: 0,
         heading: "A",
         headingPathJson: JSON.stringify(["A"]),
         content: "hello world",
@@ -265,6 +268,7 @@ describe("openAilssDb() embedding config validation", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "chunk-1",
         path: "notes/a.md",
+        chunkIndex: 0,
         heading: "A",
         headingPathJson: JSON.stringify(["A"]),
         content: "hello world",

--- a/packages/core/test/indexVault.chunk-reuse.test.ts
+++ b/packages/core/test/indexVault.chunk-reuse.test.ts
@@ -65,7 +65,7 @@ describe("indexVault() per-chunk reuse", () => {
 
         expect(first.changedFiles).toBe(1);
         expect(first.indexedChunks).toBe(3);
-        expect(embedCalls).toEqual([["hello", "world", "again"]]);
+        expect(embedCalls).toEqual([["# A\nhello", "# B\nworld", "# C\nagain"]]);
 
         // Edit only the middle chunk.
         await fs.writeFile(
@@ -102,7 +102,7 @@ describe("indexVault() per-chunk reuse", () => {
 
         expect(second.changedFiles).toBe(1);
         expect(second.indexedChunks).toBe(3);
-        expect(embedCalls[1]).toEqual(["world!"]);
+        expect(embedCalls[1]).toEqual(["# B\nworld!"]);
 
         const chunkCount = db
           .prepare("SELECT COUNT(*) as count FROM chunks WHERE path = ?")

--- a/packages/mcp/src/tools/getContext.ts
+++ b/packages/mcp/src/tools/getContext.ts
@@ -1,13 +1,28 @@
 // get_context tool
-// - semantic search + note previews
+// - semantic search + stitched evidence (multi-chunk + neighbors)
 
-import { semanticSearch } from "@ailss/core";
+import { getNoteMeta, listChunksByPathAndIndices, semanticSearch } from "@ailss/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import type { McpToolDeps } from "../mcpDeps.js";
 import { embedQuery } from "../lib/openaiEmbeddings.js";
 import { readVaultFileText } from "../lib/vaultFs.js";
+
+type EvidenceChunk = {
+  chunk_id: string;
+  chunk_index: number;
+  kind: "hit" | "neighbor";
+  distance: number | null;
+  heading: string | null;
+  heading_path: string[];
+};
+
+type StitchResult = {
+  text: string;
+  truncated: boolean;
+  used_chunk_ids: string[];
+};
 
 export function registerGetContextTool(server: McpServer, deps: McpToolDeps): void {
   const defaultTopK = parseDefaultTopKFromEnv(process.env.AILSS_GET_CONTEXT_DEFAULT_TOP_K);
@@ -17,7 +32,7 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
     {
       title: "Get context",
       description:
-        "Builds a context set for a query: semantic search over indexed chunks, then returns the top matching notes (deduped by path) with short previews (when AILSS_VAULT_PATH is set).",
+        "Builds a context set for a query: semantic search over indexed chunks, then returns the top matching notes with note metadata and stitched evidence chunks (optionally with file-start previews).",
       inputSchema: {
         query: z.string().min(1).describe("User question/task to retrieve related notes for"),
         top_k: z
@@ -27,26 +42,88 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
           .max(50)
           .default(defaultTopK)
           .describe("Maximum number of note results to return (1–50)"),
+        expand_top_k: z
+          .number()
+          .int()
+          .min(0)
+          .max(50)
+          .default(5)
+          .describe(
+            "How many of the top_k notes should include stitched evidence text (0–50). The rest return metadata only.",
+          ),
+        hit_chunks_per_note: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .default(2)
+          .describe("How many best-matching chunks to keep per note (1–5)"),
+        neighbor_window: z
+          .number()
+          .int()
+          .min(0)
+          .max(3)
+          .default(1)
+          .describe("How many neighbor chunks (±window) to stitch around the best hit (0–3)"),
+        max_evidence_chars_per_note: z
+          .number()
+          .int()
+          .min(200)
+          .max(20_000)
+          .default(1500)
+          .describe("Evidence text budget per expanded note (characters)"),
+        include_file_preview: z
+          .boolean()
+          .default(false)
+          .describe(
+            "When true, include a file-start preview (max_chars_per_note) in addition to evidence text (requires AILSS_VAULT_PATH).",
+          ),
         max_chars_per_note: z
           .number()
           .int()
           .min(200)
           .max(50_000)
           .default(800)
-          .describe("Preview size per note (characters)"),
+          .describe(
+            "File-start preview size per note (characters), when include_file_preview=true",
+          ),
       },
       outputSchema: z.object({
         query: z.string(),
         top_k: z.number().int(),
         db: z.string(),
         used_chunks_k: z.number().int(),
+        params: z.object({
+          expand_top_k: z.number().int(),
+          hit_chunks_per_note: z.number().int(),
+          neighbor_window: z.number().int(),
+          max_evidence_chars_per_note: z.number().int(),
+          include_file_preview: z.boolean(),
+          max_chars_per_note: z.number().int(),
+        }),
         results: z.array(
           z.object({
             path: z.string(),
             distance: z.number(),
+            title: z.string().nullable(),
+            summary: z.string().nullable(),
+            tags: z.array(z.string()),
+            keywords: z.array(z.string()),
             heading: z.string().nullable(),
             heading_path: z.array(z.string()),
             snippet: z.string(),
+            evidence_text: z.string().nullable(),
+            evidence_truncated: z.boolean(),
+            evidence_chunks: z.array(
+              z.object({
+                chunk_id: z.string(),
+                chunk_index: z.number().int(),
+                kind: z.enum(["hit", "neighbor"]),
+                distance: z.number().nullable(),
+                heading: z.string().nullable(),
+                heading_path: z.array(z.string()),
+              }),
+            ),
             preview: z.string().nullable(),
             preview_truncated: z.boolean(),
           }),
@@ -56,60 +133,159 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
     async (args) => {
       const queryEmbedding = await embedQuery(deps.openai, deps.embeddingModel, args.query);
 
-      // Over-fetch chunks so we can dedupe by note path.
-      const usedChunksK = Math.min(50, Math.max(args.top_k, args.top_k * 5));
-      const chunkHits = semanticSearch(deps.db, queryEmbedding, usedChunksK);
+      const desiredNotes = Math.max(1, Math.min(args.top_k, 50));
+      const hitChunksPerNote = Math.max(1, Math.min(args.hit_chunks_per_note, 5));
 
-      const bestByPath = new Map<string, (typeof chunkHits)[number]>();
-      for (const hit of chunkHits) {
-        const existing = bestByPath.get(hit.path);
-        if (!existing || hit.distance < existing.distance) {
-          bestByPath.set(hit.path, hit);
-        }
+      // Over-fetch chunks so we can return enough unique note paths.
+      // - Default cap is conservative (vaults can have many short sections).
+      const maxChunksK = 500;
+      let usedChunksK = Math.min(maxChunksK, Math.max(50, desiredNotes * 15));
+      let chunkHits = semanticSearch(deps.db, queryEmbedding, usedChunksK);
+      for (let i = 0; i < 3; i += 1) {
+        const uniquePaths = new Set(chunkHits.map((h) => h.path)).size;
+        if (uniquePaths >= desiredNotes) break;
+        if (usedChunksK >= maxChunksK) break;
+        usedChunksK = Math.min(maxChunksK, usedChunksK * 2);
+        chunkHits = semanticSearch(deps.db, queryEmbedding, usedChunksK);
       }
 
-      const ordered = Array.from(bestByPath.values())
-        .sort((a, b) => a.distance - b.distance)
-        .slice(0, args.top_k);
+      // Keep per-note top hits (distance-ordered globally, so first N per path are best).
+      const hitsByPath = new Map<string, (typeof chunkHits)[number][]>();
+      for (const hit of chunkHits) {
+        const existing = hitsByPath.get(hit.path);
+        if (!existing) {
+          hitsByPath.set(hit.path, [hit]);
+          continue;
+        }
+        if (existing.length >= hitChunksPerNote) continue;
+        existing.push(hit);
+      }
+
+      const ordered = Array.from(hitsByPath.entries())
+        .map(([path, hits]) => ({ path, hits, best: hits[0] }))
+        .filter(
+          (
+            row,
+          ): row is {
+            path: string;
+            hits: (typeof chunkHits)[number][];
+            best: (typeof chunkHits)[number];
+          } => Boolean(row.best),
+        )
+        .sort((a, b) => a.best.distance - b.best.distance)
+        .slice(0, desiredNotes);
 
       const results: Array<{
         path: string;
         distance: number;
+        title: string | null;
+        summary: string | null;
+        tags: string[];
+        keywords: string[];
         heading: string | null;
         heading_path: string[];
         snippet: string;
+        evidence_text: string | null;
+        evidence_truncated: boolean;
+        evidence_chunks: EvidenceChunk[];
         preview: string | null;
         preview_truncated: boolean;
       }> = [];
 
-      for (const hit of ordered) {
-        if (!deps.vaultPath) {
-          results.push({
-            path: hit.path,
-            distance: hit.distance,
-            heading: hit.heading,
-            heading_path: hit.headingPath,
-            snippet: hit.content.slice(0, 300),
-            preview: null,
-            preview_truncated: false,
-          });
-          continue;
+      const expandTopK = Math.max(0, Math.min(args.expand_top_k, desiredNotes));
+      const neighborWindow = Math.max(0, Math.min(args.neighbor_window, 3));
+      const perNoteEvidenceChars = Math.max(
+        200,
+        Math.min(args.max_evidence_chars_per_note, 20_000),
+      );
+      const includePreview = Boolean(args.include_file_preview && deps.vaultPath);
+
+      const maxTotalEvidenceChars = expandTopK * perNoteEvidenceChars;
+      let usedTotalEvidenceChars = 0;
+
+      for (const [rank, row] of ordered.entries()) {
+        const best = row.best;
+        if (!best) continue;
+
+        const meta = getNoteMeta(deps.db, row.path);
+        const title = meta?.title ?? null;
+        const summary = meta?.summary ?? null;
+        const tags = meta?.tags ?? [];
+        const keywords = meta?.keywords ?? [];
+
+        let evidenceText: string | null = null;
+        let evidenceTruncated = false;
+        let evidenceChunks: EvidenceChunk[] = [];
+
+        if (rank < expandTopK && usedTotalEvidenceChars < maxTotalEvidenceChars) {
+          const remainingGlobal = maxTotalEvidenceChars - usedTotalEvidenceChars;
+          const maxChars = Math.max(200, Math.min(perNoteEvidenceChars, remainingGlobal));
+
+          const wantedIndices = new Set<number>();
+          for (let d = -neighborWindow; d <= neighborWindow; d += 1) {
+            wantedIndices.add(best.chunkIndex + d);
+          }
+
+          for (const extra of row.hits.slice(1)) {
+            wantedIndices.add(extra.chunkIndex);
+          }
+
+          const chunks = listChunksByPathAndIndices(deps.db, row.path, Array.from(wantedIndices));
+
+          const hitChunkIds = new Set(row.hits.map((h) => h.chunkId));
+          const distanceByChunkId = new Map<string, number>();
+          for (const h of row.hits) {
+            distanceByChunkId.set(h.chunkId, h.distance);
+          }
+
+          const stitched = stitchChunkContents(chunks, maxChars);
+          evidenceText = stitched.text;
+          evidenceTruncated = stitched.truncated;
+          usedTotalEvidenceChars += stitched.text.length;
+
+          const usedChunkIds = new Set(stitched.used_chunk_ids);
+          evidenceChunks = chunks
+            .filter((c) => usedChunkIds.has(c.chunkId))
+            .map((c) => ({
+              chunk_id: c.chunkId,
+              chunk_index: c.chunkIndex,
+              kind: hitChunkIds.has(c.chunkId) ? "hit" : "neighbor",
+              distance: distanceByChunkId.get(c.chunkId) ?? null,
+              heading: c.heading,
+              heading_path: c.headingPath,
+            }));
         }
 
-        const { text, truncated } = await readVaultFileText({
-          vaultPath: deps.vaultPath,
-          vaultRelPath: hit.path,
-          maxChars: args.max_chars_per_note,
-        });
+        const snippetSource = evidenceText ?? best.content;
+        const snippet = snippetSource.slice(0, 300);
+
+        let preview: string | null = null;
+        let previewTruncated = false;
+        if (includePreview && deps.vaultPath) {
+          const { text, truncated } = await readVaultFileText({
+            vaultPath: deps.vaultPath,
+            vaultRelPath: row.path,
+            maxChars: args.max_chars_per_note,
+          });
+          preview = text;
+          previewTruncated = truncated;
+        }
 
         results.push({
-          path: hit.path,
-          distance: hit.distance,
-          heading: hit.heading,
-          heading_path: hit.headingPath,
-          snippet: hit.content.slice(0, 300),
-          preview: text,
-          preview_truncated: truncated,
+          path: row.path,
+          distance: best.distance,
+          title,
+          summary,
+          tags,
+          keywords,
+          heading: best.heading,
+          heading_path: best.headingPath,
+          snippet,
+          evidence_text: evidenceText,
+          evidence_truncated: evidenceTruncated,
+          evidence_chunks: evidenceChunks,
+          preview,
+          preview_truncated: previewTruncated,
         });
       }
 
@@ -118,6 +294,14 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
         top_k: args.top_k,
         db: deps.dbPath,
         used_chunks_k: usedChunksK,
+        params: {
+          expand_top_k: expandTopK,
+          hit_chunks_per_note: hitChunksPerNote,
+          neighbor_window: neighborWindow,
+          max_evidence_chars_per_note: perNoteEvidenceChars,
+          include_file_preview: includePreview,
+          max_chars_per_note: args.max_chars_per_note,
+        },
         results,
       };
 
@@ -127,6 +311,41 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
       };
     },
   );
+}
+
+function stitchChunkContents(
+  chunks: Array<{ chunkId: string; content: string }>,
+  maxChars: number,
+): StitchResult {
+  const budget = Math.max(1, Math.floor(maxChars));
+  let text = "";
+  let truncated = false;
+  const usedChunkIds: string[] = [];
+
+  for (const chunk of chunks) {
+    const part = (chunk.content ?? "").trim();
+    if (!part) continue;
+
+    const separator = text ? "\n\n" : "";
+    const next = `${text}${separator}${part}`;
+
+    if (next.length <= budget) {
+      text = next;
+      usedChunkIds.push(chunk.chunkId);
+      continue;
+    }
+
+    // Partial include
+    const remaining = budget - text.length - separator.length;
+    if (remaining > 0) {
+      text = `${text}${separator}${part.slice(0, remaining)}`;
+      usedChunkIds.push(chunk.chunkId);
+    }
+    truncated = true;
+    break;
+  }
+
+  return { text, truncated, used_chunk_ids: usedChunkIds };
 }
 
 function parseDefaultTopKFromEnv(raw: string | undefined): number {

--- a/packages/mcp/test/httpTools.getContext.test.ts
+++ b/packages/mcp/test/httpTools.getContext.test.ts
@@ -101,6 +101,7 @@ describe("MCP HTTP server (get_context)", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "a-close",
         path: "A.md",
+        chunkIndex: 0,
         heading: "A close",
         headingPathJson: JSON.stringify(["A close"]),
         content: "chunk-a-close",
@@ -110,6 +111,7 @@ describe("MCP HTTP server (get_context)", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "a-far",
         path: "A.md",
+        chunkIndex: 1,
         heading: "A far",
         headingPathJson: JSON.stringify(["A far"]),
         content: "chunk-a-far",
@@ -120,6 +122,7 @@ describe("MCP HTTP server (get_context)", () => {
       insertChunkWithEmbedding(db, {
         chunkId: "b",
         path: "B.md",
+        chunkIndex: 0,
         heading: "B",
         headingPathJson: JSON.stringify(["B"]),
         content: "chunk-b",
@@ -139,6 +142,8 @@ describe("MCP HTTP server (get_context)", () => {
         const res = await mcpToolsCall(url, TEST_TOKEN, sessionId, "get_context", {
           query: "query",
           top_k: 2,
+          expand_top_k: 0,
+          include_file_preview: true,
           max_chars_per_note: 200,
         });
 
@@ -146,7 +151,7 @@ describe("MCP HTTP server (get_context)", () => {
         const structured = getStructuredContent(res);
         expect(structured["query"]).toBe("query");
         expect(structured["top_k"]).toBe(2);
-        expect(structured["used_chunks_k"]).toBe(10);
+        expect(structured["used_chunks_k"]).toBe(50);
 
         const results = structured["results"] as Array<Record<string, unknown>>;
         expect(results).toHaveLength(2);
@@ -162,6 +167,119 @@ describe("MCP HTTP server (get_context)", () => {
         expect(results[1]?.snippet).toBe("chunk-b");
         expect(results[1]?.preview_truncated).toBe(false);
         expect(String(results[1]?.preview)).toBe("short\n");
+      } finally {
+        await close();
+        db.close();
+      }
+    });
+  });
+
+  it("returns stitched evidence chunks (hits + neighbors) without file-start previews by default", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+      const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+      const queryEmbedding = [0, 0, 0];
+      const openaiStub = {
+        embeddings: {
+          create: async () => ({ data: [{ embedding: queryEmbedding }] }),
+        },
+      } as unknown as AilssMcpRuntime["deps"]["openai"];
+
+      const runtime: AilssMcpRuntime = {
+        deps: {
+          db,
+          dbPath,
+          vaultPath: undefined,
+          openai: openaiStub,
+          embeddingModel: "test-embeddings",
+          writeLock: new AsyncMutex(),
+        },
+        enableWriteTools: false,
+      };
+
+      upsertFile(db, { path: "A.md", mtimeMs: 0, sizeBytes: 0, sha256: "a" });
+
+      // Best hit at chunk_index=1; neighbors are 0 and 2; second hit is far away at 5.
+      insertChunkWithEmbedding(db, {
+        chunkId: "a-0",
+        path: "A.md",
+        chunkIndex: 0,
+        heading: "Zero",
+        headingPathJson: JSON.stringify(["Zero"]),
+        content: "chunk-0",
+        contentSha256: "sha-a-0",
+        embedding: [2, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "a-1-best",
+        path: "A.md",
+        chunkIndex: 1,
+        heading: "Best",
+        headingPathJson: JSON.stringify(["Best"]),
+        content: "chunk-1-best",
+        contentSha256: "sha-a-1",
+        embedding: [0, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "a-2",
+        path: "A.md",
+        chunkIndex: 2,
+        heading: "Two",
+        headingPathJson: JSON.stringify(["Two"]),
+        content: "chunk-2",
+        contentSha256: "sha-a-2",
+        embedding: [2, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "a-5-hit",
+        path: "A.md",
+        chunkIndex: 5,
+        heading: "Far hit",
+        headingPathJson: JSON.stringify(["Far hit"]),
+        content: "chunk-5-hit",
+        contentSha256: "sha-a-5",
+        embedding: [0.2, 0, 0],
+      });
+
+      const { close, url } = await startAilssMcpHttpServer({
+        runtime,
+        config: { host: "127.0.0.1", port: 0, path: "/mcp", token: TEST_TOKEN },
+        maxSessions: 5,
+        idleTtlMs: 60_000,
+      });
+
+      try {
+        const sessionId = await mcpInitialize(url, TEST_TOKEN, "client-a");
+        const res = await mcpToolsCall(url, TEST_TOKEN, sessionId, "get_context", {
+          query: "query",
+          top_k: 1,
+        });
+
+        throwIfToolCallFailed(res);
+        const structured = getStructuredContent(res);
+
+        const results = structured["results"] as Array<Record<string, unknown>>;
+        expect(results).toHaveLength(1);
+
+        const first = results[0] ?? {};
+        expect(first["path"]).toBe("A.md");
+
+        // Preview is disabled by default.
+        expect(first["preview"]).toBe(null);
+        expect(first["preview_truncated"]).toBe(false);
+
+        // Evidence stitching includes best hit + neighbors (0/1/2) + extra hit (5).
+        expect(String(first["evidence_text"])).toContain("chunk-0");
+        expect(String(first["evidence_text"])).toContain("chunk-1-best");
+        expect(String(first["evidence_text"])).toContain("chunk-2");
+        expect(String(first["evidence_text"])).toContain("chunk-5-hit");
+
+        const evidenceChunks = first["evidence_chunks"] as Array<Record<string, unknown>>;
+        const indices = evidenceChunks
+          .map((c) => c["chunk_index"])
+          .sort((a, b) => Number(a) - Number(b));
+        expect(indices).toEqual([0, 1, 2, 5]);
       } finally {
         await close();
         db.close();


### PR DESCRIPTION
## What

- Add `chunks.chunk_index` (0-based) to persist per-file chunk order for stable neighbor stitching.
- Include the heading line in chunk `content` so heading-only/short sections remain searchable.
- Update `get_context` to return note metadata + stitched evidence chunks (multi-hit + neighbors) and disable file-start previews by default.

## Why

- Reduce token bloat/noise from file-start previews and provide evidence aligned to the actual matched chunks.
- Support vaults with many short/heading-only sections where embedding signal would otherwise be weak.

- Fixes #54

## How

- Core: migrate `chunks` schema/view and write `chunk_index` during indexing; add DB query helper for neighbor chunk fetch by indices.
- MCP: keep multiple hits per note, stitch best-hit neighbors (±1) + optional extra hits under per-note/global budgets; add params to tune behavior.
- Docs/tests: update tool docs and expand HTTP get_context tests for preview opt-in + evidence stitching.

