### PR TITLE
feat: add get graph context retrieval loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Full rules: `docs/standards/vault/README.md`.
 
 Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 
-- Read tools: `get_context`, `get_typed_links`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_link_backrefs`
+- Read tools: `get_context`, `get_graph_context`, `get_typed_links`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_link_backrefs`
 - Write tools (gated): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`  
   Requires `AILSS_ENABLE_WRITE_TOOLS=1` and `apply=true`.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -32,6 +32,7 @@ Read-first tools (implemented in this repo):
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
   - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
   - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000)
+- `get_graph_context`: GraphRAG-style retrieval loop (semantic seed notes + bounded typed-link expansion + curated snippets; DB-backed)
 - `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)
@@ -62,7 +63,7 @@ Frontmatter query support (current):
 
 - AILSS stores normalized frontmatter in SQLite for retrieval and graph building.
 - The MCP surface supports both:
-  - semantic retrieval via `get_context`
+  - semantic retrieval via `get_context` / `get_graph_context`
   - metadata filtering via `search_notes` + typed-link navigation/backrefs via `get_typed_links` / `find_typed_link_backrefs`
 
 Read-first tools (planned):

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,7 +24,7 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-  - Read-first tools: `get_context`, `get_typed_links`, `find_typed_link_backrefs`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+  - Read-first tools: `get_context`, `get_graph_context`, `get_typed_links`, `find_typed_link_backrefs`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
   - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
@@ -120,6 +120,7 @@ MCP tools (read-only):
 Implemented:
 
 - `get_context`: semantic retrieval for a query → returns top matching notes (deduped by path) with snippets and optional previews
+- `get_graph_context`: GraphRAG-style retrieval loop (semantic seed notes + bounded typed-link expansion + curated snippets)
 - `get_typed_links`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_link_backrefs`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)
@@ -134,7 +135,7 @@ Implemented:
 Notes on queryability (current):
 
 - AILSS stores normalized frontmatter + typed links in SQLite (used for graph expansion and retrieval).
-- The MCP surface supports both semantic retrieval (`get_context`) and structured navigation/filtering (`get_typed_links`, `find_typed_link_backrefs`, `search_notes`).
+- The MCP surface supports both semantic retrieval (`get_context`, `get_graph_context`) and structured navigation/filtering (`get_typed_links`, `find_typed_link_backrefs`, `search_notes`).
 - Frontmatter normalization coerces YAML-inferred scalars (unquoted numbers/dates) to strings for core identity fields (`id`, `created`, `updated`) so existing vault notes can remain unquoted.
 
 Planned:

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -4,6 +4,7 @@ description: "Obsidian vault notes (AILSS): search/summarize/edit (frontmatter, 
 mcp_tools:
   # Always available (read tools)
   - get_context
+  - get_graph_context
   - get_typed_links
   - resolve_note
   - read_note
@@ -27,7 +28,7 @@ Use this skill when you want to work **retrieval-first** against an AILSS Obsidi
 
 ## Core workflow
 
-1. Start with `get_context` for the user’s query (avoid guessing and avoid duplicates).
+1. Start with `get_context` or `get_graph_context` for the user’s query (avoid guessing and avoid duplicates).
 2. Use `get_typed_links` to navigate the semantic graph from a specific note (DB-backed).
    - Typed links are directional: link from the current note to what it uses/depends_on/part_of/implements; do not add reciprocal links unless explicitly requested.
 3. Use `resolve_note` when you only have `id`/`title`/a wikilink target and need a vault-relative path for `read_note`/`edit_note`.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -14,6 +14,22 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `top_k` (int, default: `10`, range: `1–50`)
   - `max_chars_per_note` (int, default: `2000`, range: `200–50,000`)
 
+### `get_graph_context`
+
+- Purpose: GraphRAG-style retrieval loop (semantic seeds + bounded typed-link expansion + curated snippets; DB-only).
+- Input:
+  - `query` (string, required)
+  - `seed_top_k` (int, default: `10`, range: `1–50`)
+  - `max_hops` (int, default: `1`, range: `0–2`)
+  - `rels` (string[], optional; default: canonical frontmatter typed-link keys)
+  - `path_prefix` (string, optional)
+  - `include_backrefs` (boolean, default: `false`)
+  - `max_notes` (int, default: `80`, range: `1–200`)
+  - `max_edges` (int, default: `2000`, range: `1–10,000`)
+  - `max_links_per_note` (int, default: `40`, range: `1–200`)
+  - `max_resolutions_per_target` (int, default: `5`, range: `1–20`)
+  - `max_chunks_per_note` (int, default: `2`, range: `1–5`)
+
 ### `get_typed_links`
 
 - Purpose: expand outgoing typed links into a bounded metadata graph (DB-only).

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -12,6 +12,7 @@ import { registerFindTypedLinkBackrefsTool } from "./tools/findTypedLinkBackrefs
 import { registerFindBrokenLinksTool } from "./tools/findBrokenLinks.js";
 import { registerFrontmatterValidateTool } from "./tools/frontmatterValidate.js";
 import { registerGetContextTool } from "./tools/getContext.js";
+import { registerGetGraphContextTool } from "./tools/getGraphContext.js";
 import { registerGetNoteTool } from "./tools/getNote.js";
 import { registerGetVaultTreeTool } from "./tools/getVaultTree.js";
 import { registerGetTypedLinksTool } from "./tools/getTypedLinks.js";
@@ -69,6 +70,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   const server = new McpServer({ name: "ailss-mcp", version: "0.1.0" });
 
   registerGetContextTool(server, deps);
+  registerGetGraphContextTool(server, deps);
   registerGetTypedLinksTool(server, deps);
   registerResolveNoteTool(server, deps);
   registerGetNoteTool(server, deps);

--- a/packages/mcp/src/tools/getGraphContext.ts
+++ b/packages/mcp/src/tools/getGraphContext.ts
@@ -1,0 +1,627 @@
+// get_graph_context tool
+// - GraphRAG-style retrieval: semantic seeds + bounded typed-link expansion + curated snippets
+
+import {
+  AILSS_TYPED_LINK_KEYS,
+  findNotesByTypedLink,
+  getNoteMeta,
+  resolveNotePathsByWikilinkTarget,
+  semanticSearch,
+} from "@ailss/core";
+import type { NoteMeta } from "@ailss/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+import { embedQuery } from "../lib/openaiEmbeddings.js";
+
+const DEFAULT_RELS = [...AILSS_TYPED_LINK_KEYS] as const;
+const HOP_PENALTY = 0.15;
+
+type GraphEdgeDirection = "outgoing" | "incoming";
+
+type RankedChunk = ReturnType<typeof semanticSearch>[number];
+
+type NodeState = {
+  path: string;
+  hop: number;
+  minSeedDistance: number;
+  graphScore: number;
+  title: string | null;
+  summary: string | null;
+  entity: string | null;
+  layer: string | null;
+  status: string | null;
+  updated: string | null;
+  tags: string[];
+  keywords: string[];
+};
+
+function normalizeRelList(input: string[] | undefined): string[] {
+  const raw = (input && input.length > 0 ? input : [...DEFAULT_RELS])
+    .map((rel) => rel.trim())
+    .filter(Boolean);
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const rel of raw) {
+    if (seen.has(rel)) continue;
+    seen.add(rel);
+    out.push(rel);
+  }
+  return out;
+}
+
+function isPathInScope(notePath: string, pathPrefix: string | null): boolean {
+  if (!pathPrefix) return true;
+  return notePath.startsWith(pathPrefix);
+}
+
+function maxSeedChunkK(seedTopK: number): number {
+  return Math.min(500, Math.max(50, seedTopK * 20));
+}
+
+function maxContextChunkK(maxNotes: number, maxChunksPerNote: number): number {
+  return Math.min(2000, Math.max(200, maxNotes * maxChunksPerNote * 8));
+}
+
+function pathWithoutMd(notePath: string): string {
+  if (notePath.toLowerCase().endsWith(".md")) return notePath.slice(0, -3);
+  return notePath;
+}
+
+function basename(notePath: string): string {
+  const normalized = notePath.replaceAll("\\", "/");
+  return normalized.split("/").pop() ?? normalized;
+}
+
+function incomingTargetsForNote(meta: NoteMeta): string[] {
+  const targets: string[] = [];
+  const seen = new Set<string>();
+  const add = (value: string | null | undefined): void => {
+    const trimmed = (value ?? "").trim();
+    if (!trimmed) return;
+    if (seen.has(trimmed)) return;
+    seen.add(trimmed);
+    targets.push(trimmed);
+  };
+
+  add(meta.noteId);
+  add(meta.title);
+  add(meta.path);
+  add(pathWithoutMd(meta.path));
+
+  const base = basename(meta.path);
+  add(base);
+  add(pathWithoutMd(base));
+
+  return targets;
+}
+
+function chunkSnippet(content: string): string {
+  return content.slice(0, 300);
+}
+
+function compareNumbersThenPath(
+  a: { score: number; path: string },
+  b: { score: number; path: string },
+) {
+  if (a.score !== b.score) return a.score - b.score;
+  return a.path.localeCompare(b.path);
+}
+
+export function registerGetGraphContextTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "get_graph_context",
+    {
+      title: "Get graph context",
+      description:
+        "GraphRAG-style retrieval: semantic seeds + bounded typed-link expansion + curated snippets (DB-first, no vault body reads).",
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .describe("User question/task to retrieve graph-grounded context for"),
+        seed_top_k: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .default(10)
+          .describe("Number of semantic seed notes to start from"),
+        max_hops: z
+          .number()
+          .int()
+          .min(0)
+          .max(2)
+          .default(1)
+          .describe("Maximum typed-link expansion depth from seed notes"),
+        rels: z
+          .array(z.string().min(1))
+          .optional()
+          .describe(
+            "Typed-link relations to include (default: canonical frontmatter typed-link keys)",
+          ),
+        path_prefix: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("Optional vault-relative path prefix to constrain retrieval + graph expansion"),
+        include_backrefs: z
+          .boolean()
+          .default(false)
+          .describe("Whether to include incoming typed-link edges during expansion"),
+        max_notes: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(80)
+          .describe("Maximum graph note nodes returned"),
+        max_edges: z
+          .number()
+          .int()
+          .min(1)
+          .max(10_000)
+          .default(2000)
+          .describe("Maximum graph edges returned"),
+        max_links_per_note: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(40)
+          .describe("Maximum typed-link edges followed per note per direction"),
+        max_resolutions_per_target: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .default(5)
+          .describe("Maximum resolved note paths per typed-link target"),
+        max_chunks_per_note: z
+          .number()
+          .int()
+          .min(1)
+          .max(5)
+          .default(2)
+          .describe("Maximum semantic snippets per returned note"),
+      },
+      outputSchema: z.object({
+        query: z.string(),
+        params: z.object({
+          seed_top_k: z.number().int(),
+          max_hops: z.number().int(),
+          rels: z.array(z.string()),
+          path_prefix: z.string().nullable(),
+          include_backrefs: z.boolean(),
+          max_notes: z.number().int(),
+          max_edges: z.number().int(),
+          max_links_per_note: z.number().int(),
+          max_resolutions_per_target: z.number().int(),
+          max_chunks_per_note: z.number().int(),
+        }),
+        db: z.string(),
+        used_seed_chunks_k: z.number().int(),
+        used_context_chunks_k: z.number().int(),
+        seeds: z.array(
+          z.object({
+            path: z.string(),
+            distance: z.number(),
+            heading: z.string().nullable(),
+            heading_path: z.array(z.string()),
+            snippet: z.string(),
+          }),
+        ),
+        graph: z.object({
+          truncated: z.boolean(),
+          nodes: z.array(
+            z.object({
+              path: z.string(),
+              hop: z.number().int().nonnegative(),
+              min_seed_distance: z.number(),
+              graph_score: z.number(),
+              title: z.string().nullable(),
+              summary: z.string().nullable(),
+              entity: z.string().nullable(),
+              layer: z.string().nullable(),
+              status: z.string().nullable(),
+              updated: z.string().nullable(),
+              tags: z.array(z.string()),
+              keywords: z.array(z.string()),
+            }),
+          ),
+          edges: z.array(
+            z.object({
+              direction: z.union([z.literal("outgoing"), z.literal("incoming")]),
+              rel: z.string(),
+              target: z.string(),
+              from_path: z.string(),
+              to_path: z.string(),
+              to_wikilink: z.string(),
+            }),
+          ),
+        }),
+        context_notes: z.array(
+          z.object({
+            path: z.string(),
+            hop: z.number().int().nonnegative(),
+            score: z.number(),
+            title: z.string().nullable(),
+            summary: z.string().nullable(),
+            entity: z.string().nullable(),
+            layer: z.string().nullable(),
+            status: z.string().nullable(),
+            updated: z.string().nullable(),
+            tags: z.array(z.string()),
+            keywords: z.array(z.string()),
+            snippets: z.array(
+              z.object({
+                distance: z.number(),
+                heading: z.string().nullable(),
+                heading_path: z.array(z.string()),
+                snippet: z.string(),
+              }),
+            ),
+          }),
+        ),
+      }),
+    },
+    async (args) => {
+      const rels = normalizeRelList(args.rels);
+      const relSet = new Set<string>(rels);
+      const pathPrefix = args.path_prefix ? args.path_prefix.trim() : null;
+
+      const queryEmbedding = await embedQuery(deps.openai, deps.embeddingModel, args.query);
+
+      const usedSeedChunksK = maxSeedChunkK(args.seed_top_k);
+      const seedChunkHits = semanticSearch(deps.db, queryEmbedding, usedSeedChunksK).filter((hit) =>
+        isPathInScope(hit.path, pathPrefix),
+      );
+
+      const seedByPath = new Map<string, RankedChunk>();
+      for (const hit of seedChunkHits) {
+        const existing = seedByPath.get(hit.path);
+        if (!existing || hit.distance < existing.distance) {
+          seedByPath.set(hit.path, hit);
+        }
+      }
+
+      const seeds = Array.from(seedByPath.values())
+        .sort((a, b) => {
+          if (a.distance !== b.distance) return a.distance - b.distance;
+          return a.path.localeCompare(b.path);
+        })
+        .slice(0, args.seed_top_k);
+
+      const metaCache = new Map<string, NoteMeta | null>();
+      const getMetaCached = (notePath: string): NoteMeta | null => {
+        if (metaCache.has(notePath)) return metaCache.get(notePath) ?? null;
+        const meta = getNoteMeta(deps.db, notePath);
+        metaCache.set(notePath, meta);
+        return meta;
+      };
+
+      const nodeMap = new Map<string, NodeState>();
+      const edgeMap = new Map<
+        string,
+        {
+          direction: GraphEdgeDirection;
+          rel: string;
+          target: string;
+          from_path: string;
+          to_path: string;
+          to_wikilink: string;
+        }
+      >();
+      const queue: Array<{ path: string; hop: number; seedDistance: number }> = [];
+      let truncated = false;
+
+      const upsertNode = (
+        notePath: string,
+        hop: number,
+        seedDistance: number,
+      ): { shouldQueue: boolean } => {
+        if (!isPathInScope(notePath, pathPrefix)) return { shouldQueue: false };
+
+        const existing = nodeMap.get(notePath);
+        const graphScore = seedDistance + hop * HOP_PENALTY;
+        if (existing) {
+          let changed = false;
+          if (hop < existing.hop) {
+            existing.hop = hop;
+            changed = true;
+          }
+          if (seedDistance < existing.minSeedDistance) {
+            existing.minSeedDistance = seedDistance;
+            changed = true;
+          }
+          const nextGraphScore = existing.minSeedDistance + existing.hop * HOP_PENALTY;
+          if (nextGraphScore < existing.graphScore) {
+            existing.graphScore = nextGraphScore;
+            changed = true;
+          }
+          return { shouldQueue: changed && hop <= args.max_hops };
+        }
+
+        if (nodeMap.size >= args.max_notes) {
+          truncated = true;
+          return { shouldQueue: false };
+        }
+
+        const meta = getMetaCached(notePath);
+        nodeMap.set(notePath, {
+          path: notePath,
+          hop,
+          minSeedDistance: seedDistance,
+          graphScore,
+          title: meta?.title ?? null,
+          summary: meta?.summary ?? null,
+          entity: meta?.entity ?? null,
+          layer: meta?.layer ?? null,
+          status: meta?.status ?? null,
+          updated: meta?.updated ?? null,
+          tags: meta?.tags ?? [],
+          keywords: meta?.keywords ?? [],
+        });
+        return { shouldQueue: hop <= args.max_hops };
+      };
+
+      const pushEdge = (edge: {
+        direction: GraphEdgeDirection;
+        rel: string;
+        target: string;
+        from_path: string;
+        to_path: string;
+        to_wikilink: string;
+      }): boolean => {
+        if (edgeMap.size >= args.max_edges) {
+          truncated = true;
+          return false;
+        }
+
+        const key = [
+          edge.direction,
+          edge.rel,
+          edge.target,
+          edge.from_path,
+          edge.to_path,
+          edge.to_wikilink,
+        ].join("|");
+        if (edgeMap.has(key)) return true;
+        edgeMap.set(key, edge);
+        return true;
+      };
+
+      for (const seed of seeds) {
+        const upserted = upsertNode(seed.path, 0, seed.distance);
+        if (!upserted.shouldQueue) continue;
+        queue.push({ path: seed.path, hop: 0, seedDistance: seed.distance });
+      }
+
+      while (queue.length > 0) {
+        const current = queue.shift();
+        if (!current) break;
+
+        const currentNode = nodeMap.get(current.path);
+        if (!currentNode) continue;
+        if (current.hop > currentNode.hop) continue;
+        if (current.hop >= args.max_hops) continue;
+
+        const meta = getMetaCached(current.path);
+        if (!meta) continue;
+
+        let outgoingFollowed = 0;
+        for (const link of meta.typedLinks) {
+          if (!relSet.has(link.rel)) continue;
+          if (outgoingFollowed >= args.max_links_per_note) {
+            truncated = true;
+            break;
+          }
+          outgoingFollowed += 1;
+
+          const resolved = resolveNotePathsByWikilinkTarget(
+            deps.db,
+            link.toTarget,
+            args.max_resolutions_per_target,
+          );
+
+          for (const match of resolved) {
+            if (!isPathInScope(match.path, pathPrefix)) continue;
+
+            const pushed = pushEdge({
+              direction: "outgoing",
+              rel: link.rel,
+              target: link.toTarget,
+              from_path: current.path,
+              to_path: match.path,
+              to_wikilink: link.toWikilink,
+            });
+            if (!pushed) break;
+
+            const nextHop = current.hop + 1;
+            const upserted = upsertNode(match.path, nextHop, current.seedDistance);
+            if (upserted.shouldQueue) {
+              queue.push({ path: match.path, hop: nextHop, seedDistance: current.seedDistance });
+            }
+          }
+
+          if (edgeMap.size >= args.max_edges) break;
+        }
+
+        if (!args.include_backrefs || edgeMap.size >= args.max_edges) continue;
+
+        const incomingTargets = incomingTargetsForNote(meta);
+        const incomingSeen = new Set<string>();
+        let incomingFollowed = 0;
+        const perTargetLimit = Math.min(1000, Math.max(50, args.max_links_per_note * 5));
+
+        for (const target of incomingTargets) {
+          if (incomingFollowed >= args.max_links_per_note) {
+            truncated = true;
+            break;
+          }
+
+          const backrefs = findNotesByTypedLink(deps.db, {
+            toTarget: target,
+            limit: perTargetLimit,
+          });
+
+          for (const backref of backrefs) {
+            if (!relSet.has(backref.rel)) continue;
+            if (!isPathInScope(backref.fromPath, pathPrefix)) continue;
+
+            const incomingKey = `${backref.rel}|${backref.fromPath}|${current.path}|${backref.toTarget}|${backref.toWikilink}`;
+            if (incomingSeen.has(incomingKey)) continue;
+            incomingSeen.add(incomingKey);
+
+            incomingFollowed += 1;
+            if (incomingFollowed > args.max_links_per_note) {
+              truncated = true;
+              break;
+            }
+
+            const pushed = pushEdge({
+              direction: "incoming",
+              rel: backref.rel,
+              target: backref.toTarget,
+              from_path: backref.fromPath,
+              to_path: current.path,
+              to_wikilink: backref.toWikilink,
+            });
+            if (!pushed) break;
+
+            const nextHop = current.hop + 1;
+            const upserted = upsertNode(backref.fromPath, nextHop, current.seedDistance);
+            if (upserted.shouldQueue) {
+              queue.push({
+                path: backref.fromPath,
+                hop: nextHop,
+                seedDistance: current.seedDistance,
+              });
+            }
+          }
+
+          if (edgeMap.size >= args.max_edges) break;
+        }
+      }
+
+      const candidatePaths = new Set(nodeMap.keys());
+      const usedContextChunksK = candidatePaths.size
+        ? maxContextChunkK(args.max_notes, args.max_chunks_per_note)
+        : 0;
+      const contextChunkHits = usedContextChunksK
+        ? semanticSearch(deps.db, queryEmbedding, usedContextChunksK).filter(
+            (hit) => candidatePaths.has(hit.path) && isPathInScope(hit.path, pathPrefix),
+          )
+        : [];
+
+      const snippetsByPath = new Map<string, RankedChunk[]>();
+      for (const hit of contextChunkHits) {
+        const snippets = snippetsByPath.get(hit.path) ?? [];
+        snippets.push(hit);
+        snippets.sort((a, b) => a.distance - b.distance);
+        if (snippets.length > args.max_chunks_per_note) {
+          snippets.length = args.max_chunks_per_note;
+        }
+        snippetsByPath.set(hit.path, snippets);
+      }
+
+      const nodes = Array.from(nodeMap.values())
+        .sort((a, b) => {
+          if (a.hop !== b.hop) return a.hop - b.hop;
+          return compareNumbersThenPath(
+            { score: a.graphScore, path: a.path },
+            { score: b.graphScore, path: b.path },
+          );
+        })
+        .map((node) => ({
+          path: node.path,
+          hop: node.hop,
+          min_seed_distance: node.minSeedDistance,
+          graph_score: node.graphScore,
+          title: node.title,
+          summary: node.summary,
+          entity: node.entity,
+          layer: node.layer,
+          status: node.status,
+          updated: node.updated,
+          tags: node.tags,
+          keywords: node.keywords,
+        }));
+
+      const edges = Array.from(edgeMap.values()).sort((a, b) => {
+        if (a.from_path !== b.from_path) return a.from_path.localeCompare(b.from_path);
+        if (a.to_path !== b.to_path) return a.to_path.localeCompare(b.to_path);
+        if (a.direction !== b.direction) return a.direction.localeCompare(b.direction);
+        if (a.rel !== b.rel) return a.rel.localeCompare(b.rel);
+        if (a.target !== b.target) return a.target.localeCompare(b.target);
+        return a.to_wikilink.localeCompare(b.to_wikilink);
+      });
+
+      const contextNotes = Array.from(nodeMap.values())
+        .map((node) => {
+          const snippets = (snippetsByPath.get(node.path) ?? []).map((hit) => ({
+            distance: hit.distance,
+            heading: hit.heading,
+            heading_path: hit.headingPath,
+            snippet: chunkSnippet(hit.content),
+          }));
+          const semanticDistance = snippets[0]?.distance ?? node.minSeedDistance + 1;
+          const score = semanticDistance + node.hop * HOP_PENALTY;
+          return {
+            path: node.path,
+            hop: node.hop,
+            score,
+            title: node.title,
+            summary: node.summary,
+            entity: node.entity,
+            layer: node.layer,
+            status: node.status,
+            updated: node.updated,
+            tags: node.tags,
+            keywords: node.keywords,
+            snippets,
+          };
+        })
+        .sort((a, b) => compareNumbersThenPath({ score: a.score, path: a.path }, b));
+
+      const payload = {
+        query: args.query,
+        params: {
+          seed_top_k: args.seed_top_k,
+          max_hops: args.max_hops,
+          rels,
+          path_prefix: pathPrefix,
+          include_backrefs: args.include_backrefs,
+          max_notes: args.max_notes,
+          max_edges: args.max_edges,
+          max_links_per_note: args.max_links_per_note,
+          max_resolutions_per_target: args.max_resolutions_per_target,
+          max_chunks_per_note: args.max_chunks_per_note,
+        },
+        db: deps.dbPath,
+        used_seed_chunks_k: usedSeedChunksK,
+        used_context_chunks_k: usedContextChunksK,
+        seeds: seeds.map((seed) => ({
+          path: seed.path,
+          distance: seed.distance,
+          heading: seed.heading,
+          heading_path: seed.headingPath,
+          snippet: chunkSnippet(seed.content),
+        })),
+        graph: {
+          truncated,
+          nodes,
+          edges,
+        },
+        context_notes: contextNotes,
+      };
+
+      return {
+        structuredContent: payload,
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp/test/httpTools.getGraphContext.test.ts
+++ b/packages/mcp/test/httpTools.getGraphContext.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+
+import path from "node:path";
+
+import type { AilssMcpRuntime } from "../src/createAilssMcpServer.js";
+import { AsyncMutex } from "../src/lib/asyncMutex.js";
+import { startAilssMcpHttpServer } from "../src/httpServer.js";
+
+import {
+  insertChunkWithEmbedding,
+  openAilssDb,
+  replaceNoteKeywords,
+  replaceNoteTags,
+  replaceTypedLinks,
+  upsertFile,
+  upsertNote,
+} from "@ailss/core";
+
+import {
+  assertArray,
+  getStructuredContent,
+  mcpInitialize,
+  mcpToolsCall,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+const TEST_TOKEN = "test-token";
+
+function upsertIndexedNote(params: {
+  runtime: AilssMcpRuntime;
+  path: string;
+  title: string;
+  summary: string;
+  embedding: number[];
+  typedLinks?: Array<{ rel: string; target: string }>;
+  tags?: string[];
+  keywords?: string[];
+}): void {
+  const now = new Date().toISOString().slice(0, 19);
+  const db = params.runtime.deps.db;
+
+  upsertFile(db, { path: params.path, mtimeMs: 0, sizeBytes: 0, sha256: `${params.path}-sha` });
+  upsertNote(db, {
+    path: params.path,
+    noteId: path.basename(params.path, ".md"),
+    created: now,
+    title: params.title,
+    summary: params.summary,
+    entity: "concept",
+    layer: "conceptual",
+    status: "draft",
+    updated: now,
+    frontmatterJson: JSON.stringify({
+      id: path.basename(params.path, ".md"),
+      title: params.title,
+      summary: params.summary,
+      tags: params.tags ?? [],
+      keywords: params.keywords ?? [],
+    }),
+  });
+  replaceNoteTags(db, params.path, params.tags ?? []);
+  replaceNoteKeywords(db, params.path, params.keywords ?? []);
+  replaceTypedLinks(
+    db,
+    params.path,
+    (params.typedLinks ?? []).map((link, index) => ({
+      rel: link.rel,
+      toTarget: link.target,
+      toWikilink: `[[${link.target}]]`,
+      position: index,
+    })),
+  );
+  insertChunkWithEmbedding(db, {
+    chunkId: `${params.path}-chunk`,
+    path: params.path,
+    heading: params.title,
+    headingPathJson: JSON.stringify([params.title]),
+    content: `${params.title} content`,
+    contentSha256: `${params.path}-chunk-sha`,
+    embedding: params.embedding,
+  });
+}
+
+describe("MCP HTTP server (get_graph_context)", () => {
+  it("returns graph-rag payload with scoped outgoing expansion", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+      const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+      const queryEmbedding = [0, 0, 0];
+      const openaiStub = {
+        embeddings: {
+          create: async () => ({ data: [{ embedding: queryEmbedding }] }),
+        },
+      } as unknown as AilssMcpRuntime["deps"]["openai"];
+
+      const runtime: AilssMcpRuntime = {
+        deps: {
+          db,
+          dbPath,
+          vaultPath: undefined,
+          openai: openaiStub,
+          embeddingModel: "test-embeddings",
+          writeLock: new AsyncMutex(),
+        },
+        enableWriteTools: false,
+      };
+
+      upsertIndexedNote({
+        runtime,
+        path: "Domain/A.md",
+        title: "A",
+        summary: "summary A",
+        embedding: [0, 0, 0],
+        typedLinks: [
+          { rel: "uses", target: "B" },
+          { rel: "uses", target: "X" },
+        ],
+      });
+      upsertIndexedNote({
+        runtime,
+        path: "Domain/B.md",
+        title: "B",
+        summary: "summary B",
+        embedding: [0.1, 0, 0],
+        typedLinks: [{ rel: "depends_on", target: "C" }],
+      });
+      upsertIndexedNote({
+        runtime,
+        path: "Domain/C.md",
+        title: "C",
+        summary: "summary C",
+        embedding: [0.2, 0, 0],
+      });
+      upsertIndexedNote({
+        runtime,
+        path: "Other/X.md",
+        title: "X",
+        summary: "summary X",
+        embedding: [0.05, 0, 0],
+      });
+
+      const { close, url } = await startAilssMcpHttpServer({
+        runtime,
+        config: { host: "127.0.0.1", port: 0, path: "/mcp", token: TEST_TOKEN },
+        maxSessions: 5,
+        idleTtlMs: 60_000,
+      });
+
+      try {
+        const sessionId = await mcpInitialize(url, TEST_TOKEN, "client-a");
+        const res = await mcpToolsCall(url, TEST_TOKEN, sessionId, "get_graph_context", {
+          query: "query",
+          seed_top_k: 2,
+          max_hops: 1,
+          path_prefix: "Domain/",
+          rels: ["uses", "depends_on"],
+          include_backrefs: false,
+          max_notes: 20,
+          max_edges: 20,
+          max_links_per_note: 10,
+          max_chunks_per_note: 2,
+        });
+
+        const structured = getStructuredContent(res);
+
+        const seeds = structured["seeds"];
+        assertArray(seeds, "seeds");
+        expect(seeds.length).toBeGreaterThanOrEqual(1);
+        expect((seeds[0] as Record<string, unknown>)["path"]).toBe("Domain/A.md");
+
+        const graph = structured["graph"] as Record<string, unknown>;
+        const nodes = graph["nodes"];
+        assertArray(nodes, "graph.nodes");
+        const nodePaths = nodes.map((node) => (node as Record<string, unknown>)["path"]).sort();
+        expect(nodePaths).toEqual(["Domain/A.md", "Domain/B.md", "Domain/C.md"]);
+
+        const edges = graph["edges"];
+        assertArray(edges, "graph.edges");
+        expect(edges.length).toBe(2);
+        const edgeDirections = edges.map(
+          (edge) => (edge as Record<string, unknown>)["direction"] as string,
+        );
+        expect(new Set(edgeDirections)).toEqual(new Set(["outgoing"]));
+
+        const edgeTargets = edges
+          .map((edge) => (edge as Record<string, unknown>)["to_path"])
+          .sort();
+        expect(edgeTargets).toEqual(["Domain/B.md", "Domain/C.md"]);
+
+        const contextNotes = structured["context_notes"];
+        assertArray(contextNotes, "context_notes");
+        expect(contextNotes.length).toBe(3);
+        expect(
+          contextNotes.map((note) => (note as Record<string, unknown>)["path"]).sort(),
+        ).toEqual(["Domain/A.md", "Domain/B.md", "Domain/C.md"]);
+      } finally {
+        await close();
+        db.close();
+      }
+    });
+  });
+
+  it("includes incoming edges when include_backrefs=true", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+      const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+      const queryEmbedding = [0, 0, 0];
+      const openaiStub = {
+        embeddings: {
+          create: async () => ({ data: [{ embedding: queryEmbedding }] }),
+        },
+      } as unknown as AilssMcpRuntime["deps"]["openai"];
+
+      const runtime: AilssMcpRuntime = {
+        deps: {
+          db,
+          dbPath,
+          vaultPath: undefined,
+          openai: openaiStub,
+          embeddingModel: "test-embeddings",
+          writeLock: new AsyncMutex(),
+        },
+        enableWriteTools: false,
+      };
+
+      upsertIndexedNote({
+        runtime,
+        path: "Domain/A.md",
+        title: "A",
+        summary: "summary A",
+        embedding: [0, 0, 0],
+      });
+      upsertIndexedNote({
+        runtime,
+        path: "Domain/B.md",
+        title: "B",
+        summary: "summary B",
+        embedding: [0.2, 0, 0],
+        typedLinks: [{ rel: "part_of", target: "A" }],
+      });
+
+      const { close, url } = await startAilssMcpHttpServer({
+        runtime,
+        config: { host: "127.0.0.1", port: 0, path: "/mcp", token: TEST_TOKEN },
+        maxSessions: 5,
+        idleTtlMs: 60_000,
+      });
+
+      try {
+        const sessionId = await mcpInitialize(url, TEST_TOKEN, "client-b");
+        const res = await mcpToolsCall(url, TEST_TOKEN, sessionId, "get_graph_context", {
+          query: "query",
+          seed_top_k: 1,
+          max_hops: 1,
+          path_prefix: "Domain/",
+          rels: ["part_of"],
+          include_backrefs: true,
+          max_notes: 20,
+          max_edges: 20,
+          max_links_per_note: 10,
+          max_chunks_per_note: 1,
+        });
+
+        const structured = getStructuredContent(res);
+        const graph = structured["graph"] as Record<string, unknown>;
+        const edges = graph["edges"];
+        assertArray(edges, "graph.edges");
+        expect(edges.length).toBe(1);
+
+        const edge = edges[0] as Record<string, unknown>;
+        expect(edge["direction"]).toBe("incoming");
+        expect(edge["from_path"]).toBe("Domain/B.md");
+        expect(edge["to_path"]).toBe("Domain/A.md");
+
+        const nodes = graph["nodes"];
+        assertArray(nodes, "graph.nodes");
+        expect(nodes.map((node) => (node as Record<string, unknown>)["path"]).sort()).toEqual([
+          "Domain/A.md",
+          "Domain/B.md",
+        ]);
+      } finally {
+        await close();
+        db.close();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What

- Add a new MCP read tool `get_graph_context` that runs a GraphRAG-style retrieval loop (semantic seeds, bounded typed-link expansion, and curated snippets) in one call.
- Register the new tool in the MCP server runtime and expose structured output with seeds, graph nodes/edges, and ranked context notes.
- Add HTTP integration tests for scoped outgoing expansion and optional incoming backrefs (`include_backrefs=true`).
- Update docs and skill metadata to include `get_graph_context` across tool references and workflow guidance.

## Why

- Reduce client-side orchestration for graph-grounded retrieval by replacing multi-tool chaining with a single bounded tool call.
- Improve context quality for note analysis/restructuring while keeping retrieval DB-first and safety-bounded.
- Fixes #51

## How

- Implement `packages/mcp/src/tools/getGraphContext.ts` with query embedding, seed selection, hop-bounded typed-link traversal (`max_hops`), relation filtering (`rels`), scope filtering (`path_prefix`), and deterministic ranking.
- Support optional incoming expansion using typed-link backrefs when `include_backrefs=true`.
- Add tests in `packages/mcp/test/httpTools.getGraphContext.test.ts` and keep docs/tool-list consistency green.
- Validation run: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm typecheck:repo`, `pnpm test`.
