### PR TITLE
feat: prefix chunk embeddings with title summary and heading path

### DIFF
--- a/docs/architecture/data-db.md
+++ b/docs/architecture/data-db.md
@@ -26,6 +26,7 @@ Stores chunk-level text and metadata.
 - `chunk_index` (0-based order within the file)
 - `heading`, `heading_path_json`
 - `content`, `content_sha256`
+- `embedding_input_sha256`: sha256 of the actual embedding input string
 
 ### `db_meta` table
 
@@ -100,7 +101,14 @@ Example `to_wikilink` value:
    - Delete chunks that no longer exist (including vec0 rows)
    - Update metadata for chunks that still exist (heading path, content, sha, timestamps)
 7. Generate embeddings via the OpenAI embeddings API only for chunks that need them
-   - Unchanged chunks reuse existing embeddings
+   - Embedding input format:
+     - `Title: <note title>`
+     - `Summary: <note summary>`
+     - `Heading path: <full heading path joined by " > ">`
+     - `---`
+     - `<chunk.content>` (stored chunk body; unchanged in DB)
+   - Reuse/dedupe is keyed by `embedding_input_sha256` (not just raw chunk body hash)
+   - If note title/summary/heading path changes, chunks are re-embedded even when chunk body text is unchanged
 8. Insert new `chunks`, `chunk_embeddings`, and `chunk_rowids` for newly introduced chunks
 
 ## Search flow

--- a/packages/core/src/db/types.ts
+++ b/packages/core/src/db/types.ts
@@ -15,5 +15,6 @@ export type IndexedChunkRow = {
   heading_path_json: string;
   content: string;
   content_sha256: string;
+  embedding_input_sha256: string;
   updated_at: string;
 };

--- a/packages/indexer/test/indexVault.test.ts
+++ b/packages/indexer/test/indexVault.test.ts
@@ -26,7 +26,14 @@ describe("indexVault (wrapper)", () => {
       await fs.mkdir(vaultPath, { recursive: true });
       await fs.writeFile(
         path.join(vaultPath, "Note.md"),
-        ["---", "id: 20260108123456", "---", "Hello"].join("\n") + "\n",
+        [
+          "---",
+          "id: 20260108123456",
+          "title: Note",
+          "summary: Wrapper test summary",
+          "---",
+          "Hello",
+        ].join("\n") + "\n",
         "utf8",
       );
 
@@ -70,7 +77,7 @@ describe("indexVault (wrapper)", () => {
         expect(calls.length).toBe(1);
         expect(calls[0]).toEqual({
           model: embeddingModel,
-          input: ["Hello"],
+          input: ["Title: Note\nSummary: Wrapper test summary\nHeading path: \n---\nHello"],
           encoding_format: "float",
         });
 


### PR DESCRIPTION
## What

- Prefix chunk embedding inputs with note metadata: `Title`, `Summary`, and full `Heading path` before the chunk body.
- Keep stored `chunks.content` unchanged while introducing `chunks.embedding_input_sha256` for embedding-input identity.
- Re-embed chunks when embedding input changes (for example title/summary/heading-path updates), even if chunk body text is unchanged.
- Add DB migration/meta validation for `embedding_input_version` to prevent mixing incompatible embedding input formats.

## Why

- Heading-only/short chunks can have weak semantic signal when embedded from body text alone.
- Metadata-prefixed embedding input improves retrieval signal without changing chunk boundaries or `get_context` output shape.
- Fixes #62

## How

- Updated `packages/core/src/indexing/indexVault.ts` to build per-chunk embedding input strings and dedupe/reuse embeddings by embedding-input hash.
- Updated DB schema/queries in `packages/core/src/db/migrate.ts` and `packages/core/src/db/queries.ts` to persist and use `embedding_input_sha256`.
- Added/updated tests in `packages/core/test/indexVault.chunk-reuse.test.ts`, `packages/core/test/db.test.ts`, and `packages/indexer/test/indexVault.test.ts`.
- Updated docs in `docs/architecture/data-db.md`.
- Validation commands run:
  - `pnpm exec vitest run packages/core/test packages/indexer/test`
  - `pnpm --filter @ailss/core typecheck && pnpm --filter @ailss/indexer typecheck`
  - `pnpm exec prettier --check docs/architecture/data-db.md packages/core/src/db/migrate.ts packages/core/src/db/queries.ts packages/core/src/db/types.ts packages/core/src/indexing/indexVault.ts packages/core/test/db.test.ts packages/core/test/indexVault.chunk-reuse.test.ts packages/indexer/test/indexVault.test.ts`
  - `pnpm check` (via pre-push hook)
