### PR TITLE
feat: add single-note typed-link canonicalization tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Full rules: `docs/standards/vault/README.md`.
 Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 
 - Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`
-- Write tools (gated): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`  
+- Write tools (gated): `capture_note`, `canonicalize_typed_links`, `edit_note`, `improve_frontmatter`, `relocate_note`  
   Requires `AILSS_ENABLE_WRITE_TOOLS=1` and `apply=true`.
 
 ## Docs

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -73,6 +73,7 @@ Read-first tools (planned):
 Explicit write tools (apply, implemented):
 
 - `capture_note`: capture a new inbox note with required frontmatter (default folder: `100. Inbox`; supports dry-run)
+- `canonicalize_typed_links`: canonicalize frontmatter typed-link targets in one note to vault-relative paths when resolution is unique (supports dry-run; never guesses ambiguous/missing targets)
 - `edit_note`: apply line-based patch ops to an existing note (supports dry-run and optional sha256 guard; reindexes by default)
   - Example: `ops: [{ op: "replace_lines", from_line: 15, to_line: 15, text: "hello world" }]`
 - `improve_frontmatter`: normalize/add required frontmatter keys for a note (supports dry-run; can optionally fix identity mismatches)

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,8 +24,8 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-  - Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
-  - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`
+- Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+- Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `canonicalize_typed_links`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
   - UI: status modals for indexing and the localhost MCP service
@@ -156,6 +156,9 @@ Write tools (explicit apply):
 - `capture_note`: create a new note in `<vault>/100. Inbox/` (default) with full frontmatter (gated; requires `AILSS_ENABLE_WRITE_TOOLS=1`)
   - Supports `apply=false` dry-run (preview) and never overwrites existing notes by default
   - By default reindexes the created path (set `reindex_after_apply=false` to skip)
+- `canonicalize_typed_links`: canonicalize frontmatter typed-link targets in a single note to vault-relative paths when resolution is unique (gated; requires `AILSS_ENABLE_WRITE_TOOLS=1`)
+  - Supports `apply=false` dry-run (preview); keeps unresolved/ambiguous targets unchanged and reports them
+  - For targets containing `/`, resolution is strict path match only (no suffix matching)
 - `edit_note`: apply line-based patch ops to an existing `.md` note (gated; requires `AILSS_ENABLE_WRITE_TOOLS=1`)
   - Supports `apply=false` dry-run (preview); line numbers are 1-based; append via `insert_lines` at `lineCount+1`
   - Optional `expected_sha256` guard; by default reindexes the edited path (set `reindex_after_apply=false` to skip)
@@ -279,6 +282,7 @@ Phase 3 — Codex-triggered writes over MCP (no per-edit UI)
 
 - Status: implemented
 - Expose explicit write tools over the localhost MCP server when enabled:
+  - `canonicalize_typed_links` (canonicalize frontmatter typed-link targets in one note; default apply=false)
   - `edit_note` (apply line-based patch ops; default apply=false)
   - `capture_note` (create new note in `<vault>/100. Inbox/` by default)
   - `relocate_note` (move/rename a note; updates frontmatter `updated` when present)

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -16,6 +16,7 @@ mcp_tools:
   - list_keywords
   # Only when write tools are enabled (AILSS_ENABLE_WRITE_TOOLS=1)
   - capture_note
+  - canonicalize_typed_links
   - edit_note
   - improve_frontmatter
   - relocate_note
@@ -71,7 +72,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
 - For new notes, prefer `capture_note` so required frontmatter keys exist and `id` matches `created`.
   - When capturing, set non-default frontmatter via `frontmatter` overrides (at least `entity`/`layer`/`status`/`summary` when known).
   - Prefer reusing existing `tags`/`keywords` by checking `list_tags` / `list_keywords` first (avoid near-duplicates).
-- Default policy for `capture_note` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
+- Default policy for `capture_note` / `canonicalize_typed_links` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
   - Only pause when the user explicitly requests “preview only” or the preview indicates a suspicious target.
 - Do not override identity fields (`id`, `created`) unless the user explicitly asks.
 - For line-based edits, fetch the note via `read_note`, then compute exact anchors + line numbers (do not guess).
@@ -122,7 +123,7 @@ cites: ["[[Some Note]]"]
 
 ## Safe writes (when enabled)
 
-- Default policy for `capture_note` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
+- Default policy for `capture_note` / `canonicalize_typed_links` / `edit_note` / `improve_frontmatter`: do `apply=false` preview, then proceed with `apply=true` automatically (auto-apply).
   - Only pause when the user explicitly requests “preview only” or the preview indicates a suspicious target.
 - For edits, use `expected_sha256` to avoid overwriting concurrent changes.
 - Keep identity fields safe: do not override `id`/`created` unless the user explicitly requests it.

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -122,6 +122,18 @@ Write tools are registered only when `AILSS_ENABLE_WRITE_TOOLS=1` and they only 
   - `apply` (boolean, default: `false`)
   - `reindex_after_apply` (boolean, default: `true`)
 
+### `canonicalize_typed_links`
+
+- Purpose: canonicalize frontmatter typed-link targets in a single note to deterministic vault-relative paths when resolution is unique (filesystem + DB; requires `AILSS_VAULT_PATH`).
+- Input:
+  - `path` (string, required)
+  - `apply` (boolean, default: `false`)
+  - `reindex_after_apply` (boolean, default: `true`)
+- Notes:
+  - Scope is frontmatter typed-link keys only (does not touch body wikilinks).
+  - If a target is unresolved or ambiguous, the tool keeps it unchanged and reports it.
+  - Targets containing `/` use strict vault-relative path resolution (no suffix matching).
+
 ### `edit_note`
 
 - Purpose: apply line-based patch ops to an existing note (filesystem; requires `AILSS_VAULT_PATH`).

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -7,6 +7,7 @@ import { AsyncMutex } from "./lib/asyncMutex.js";
 import { embeddingDimForModel } from "./lib/openaiEmbeddings.js";
 import type { McpToolDeps } from "./mcpDeps.js";
 import { registerCaptureNoteTool } from "./tools/captureNote.js";
+import { registerCanonicalizeTypedLinksTool } from "./tools/canonicalizeTypedLinks.js";
 import { registerEditNoteTool } from "./tools/editNote.js";
 import { registerExpandTypedLinksOutgoingTool } from "./tools/expandTypedLinksOutgoing.js";
 import { registerFindBrokenLinksTool } from "./tools/findBrokenLinks.js";
@@ -82,6 +83,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
 
   if (runtime.enableWriteTools) {
     registerCaptureNoteTool(server, deps);
+    registerCanonicalizeTypedLinksTool(server, deps);
     registerEditNoteTool(server, deps);
     registerImproveFrontmatterTool(server, deps);
     registerRelocateNoteTool(server, deps);

--- a/packages/mcp/src/tools/canonicalizeTypedLinks.ts
+++ b/packages/mcp/src/tools/canonicalizeTypedLinks.ts
@@ -1,0 +1,468 @@
+// canonicalize_typed_links tool
+// - single-note frontmatter typed-link canonicalization
+
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+import {
+  AILSS_TYPED_LINK_KEYS,
+  isDefaultIgnoredVaultRelPath,
+  parseMarkdownNote,
+  resolveNotePathsByWikilinkTarget,
+} from "@ailss/core";
+import type { AilssDb, ResolvedNoteTarget } from "@ailss/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+import { reindexVaultPaths } from "../lib/reindexVaultPaths.js";
+import { readVaultFileFullText, writeVaultFileText } from "../lib/vaultFs.js";
+
+type ReplacementEdit = {
+  rel: string;
+  index: number;
+  before: string;
+  after: string;
+  target_before: string;
+  target_after: string;
+};
+
+type UnresolvedItem = {
+  rel: string;
+  index: number;
+  before: string;
+  target: string;
+};
+
+type AmbiguousItem = {
+  rel: string;
+  index: number;
+  before: string;
+  target: string;
+  candidates: Array<{
+    path: string;
+    title: string | null;
+    matched_by: "path" | "note_id" | "title";
+  }>;
+};
+
+type FrontmatterSplit = {
+  body: string;
+};
+
+const MAX_REPORTED_CANDIDATES = 5;
+const RESOLVE_LIMIT = 20;
+
+function sha256HexUtf8(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function normalizeNewlines(input: string): string {
+  return (input ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+function splitFrontmatter(markdown: string): FrontmatterSplit | null {
+  const normalized = normalizeNewlines(markdown);
+  const input = normalized.startsWith("\ufeff") ? normalized.slice(1) : normalized;
+  if (!input.startsWith("---\n")) return null;
+
+  const lines = input.split("\n");
+  if ((lines[0] ?? "") !== "---") return null;
+
+  let end = -1;
+  for (let i = 1; i < lines.length; i += 1) {
+    const line = lines[i] ?? "";
+    if (line === "---" || line === "...") {
+      end = i;
+      break;
+    }
+  }
+
+  if (end === -1) return null;
+
+  return {
+    body: lines.slice(end + 1).join("\n"),
+  };
+}
+
+function yamlScalar(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") {
+    if (!value) return '""';
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}
+
+function renderFrontmatterYaml(frontmatter: Record<string, unknown>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(frontmatter)) {
+    const serialized = yamlScalar(value);
+    if (!serialized) lines.push(`${key}:`);
+    else lines.push(`${key}: ${serialized}`);
+  }
+  return lines.join("\n");
+}
+
+function renderMarkdownWithFrontmatter(frontmatter: Record<string, unknown>, body: string): string {
+  return `---\n${renderFrontmatterYaml(frontmatter)}\n---\n${body}`;
+}
+
+function removeMarkdownExtension(vaultRelPath: string): string {
+  return vaultRelPath.toLowerCase().endsWith(".md") ? vaultRelPath.slice(0, -3) : vaultRelPath;
+}
+
+function splitTargetAndDisplay(raw: string): {
+  target_for_resolution: string;
+  display_for_canonical_link: string;
+} {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return {
+      target_for_resolution: "",
+      display_for_canonical_link: "",
+    };
+  }
+
+  if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
+    const inner = trimmed.slice(2, -2).trim();
+    const pipeIndex = inner.indexOf("|");
+    const left = (pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner).trim();
+    const right = (pipeIndex >= 0 ? inner.slice(pipeIndex + 1) : "").trim();
+    const targetForResolution = left.split("#")[0]?.trim() ?? "";
+    const displayForCanonicalLink = right || left || inner;
+
+    return {
+      target_for_resolution: targetForResolution || left || inner,
+      display_for_canonical_link: displayForCanonicalLink,
+    };
+  }
+
+  const targetWithoutDisplay = trimmed.split("|")[0]?.trim() ?? "";
+  const targetForResolution = targetWithoutDisplay.split("#")[0]?.trim() ?? "";
+  return {
+    target_for_resolution: targetForResolution || trimmed,
+    display_for_canonical_link: trimmed,
+  };
+}
+
+function resolveStrictPathTarget(
+  db: AilssDb,
+  target: string,
+  limit: number,
+): Array<{
+  path: string;
+  title: string | null;
+  matchedBy: "path";
+}> {
+  const normalized = target.trim().replaceAll("\\", "/").replace(/^\/+/, "");
+  if (!normalized) return [];
+
+  const withExt = normalized.toLowerCase().endsWith(".md") ? normalized : `${normalized}.md`;
+  const rows = db
+    .prepare(
+      `
+        SELECT path, title
+        FROM notes
+        WHERE path = ?
+        ORDER BY path
+        LIMIT ?
+      `,
+    )
+    .all(withExt, limit) as Array<{ path: string; title: string | null }>;
+
+  return rows.map((row) => ({ path: row.path, title: row.title, matchedBy: "path" }));
+}
+
+function resolveTargetCandidates(db: AilssDb, target: string): ResolvedNoteTarget[] {
+  if (target.includes("/")) {
+    return resolveStrictPathTarget(db, target, RESOLVE_LIMIT);
+  }
+  return resolveNotePathsByWikilinkTarget(db, target, RESOLVE_LIMIT);
+}
+
+function canonicalWikilink(pathNoExt: string, display: string): string {
+  return `[[${pathNoExt}|${display}]]`;
+}
+
+export function registerCanonicalizeTypedLinksTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "canonicalize_typed_links",
+    {
+      title: "Canonicalize typed links",
+      description:
+        "Canonicalizes frontmatter typed-link targets in a single note to deterministic vault-relative paths when resolution is unique. Dry-run by default.",
+      inputSchema: {
+        path: z
+          .string()
+          .min(1)
+          .describe('Vault-relative Markdown note path (e.g. "Projects/Plan.md")'),
+        apply: z
+          .boolean()
+          .default(false)
+          .describe("Apply file write; false = dry-run (preview only)"),
+        reindex_after_apply: z
+          .boolean()
+          .default(true)
+          .describe("If apply=true and content changed, also reindex this path into the DB"),
+      },
+      outputSchema: z.object({
+        path: z.string(),
+        applied: z.boolean(),
+        changed: z.boolean(),
+        before_sha256: z.string(),
+        after_sha256: z.string(),
+        edits: z.array(
+          z.object({
+            rel: z.string(),
+            index: z.number().int().nonnegative(),
+            before: z.string(),
+            after: z.string(),
+            target_before: z.string(),
+            target_after: z.string(),
+          }),
+        ),
+        unresolved: z.array(
+          z.object({
+            rel: z.string(),
+            index: z.number().int().nonnegative(),
+            before: z.string(),
+            target: z.string(),
+          }),
+        ),
+        ambiguous: z.array(
+          z.object({
+            rel: z.string(),
+            index: z.number().int().nonnegative(),
+            before: z.string(),
+            target: z.string(),
+            candidates: z.array(
+              z.object({
+                path: z.string(),
+                title: z.string().nullable(),
+                matched_by: z.union([z.literal("path"), z.literal("note_id"), z.literal("title")]),
+              }),
+            ),
+          }),
+        ),
+        needs_reindex: z.boolean(),
+        reindexed: z.boolean(),
+        reindex_summary: z
+          .object({
+            changed_files: z.number().int().nonnegative(),
+            indexed_chunks: z.number().int().nonnegative(),
+            deleted_files: z.number().int().nonnegative(),
+          })
+          .nullable(),
+        reindex_error: z.string().nullable(),
+      }),
+    },
+    async (args) => {
+      const vaultPath = deps.vaultPath;
+      if (!vaultPath) {
+        throw new Error("Cannot canonicalize typed links because AILSS_VAULT_PATH is not set.");
+      }
+      if (path.posix.extname(args.path).toLowerCase() !== ".md") {
+        throw new Error(`Refusing to edit non-markdown file: path="${args.path}".`);
+      }
+      if (isDefaultIgnoredVaultRelPath(args.path)) {
+        throw new Error(`Refusing to edit ignored path: path="${args.path}".`);
+      }
+
+      const run = async () => {
+        const beforeText = await readVaultFileFullText({ vaultPath, vaultRelPath: args.path });
+        const beforeSha256 = sha256HexUtf8(beforeText);
+        const parsed = parseMarkdownNote(beforeText);
+        const split = splitFrontmatter(beforeText);
+
+        const frontmatter = (parsed.frontmatter ?? {}) as Record<string, unknown>;
+        const nextFrontmatter: Record<string, unknown> = { ...frontmatter };
+
+        const edits: ReplacementEdit[] = [];
+        const unresolved: UnresolvedItem[] = [];
+        const ambiguous: AmbiguousItem[] = [];
+
+        const resolveCache = new Map<string, ResolvedNoteTarget[]>();
+        const resolveCached = (target: string): ResolvedNoteTarget[] => {
+          const key = target.trim();
+          if (!key) return [];
+          if (resolveCache.has(key)) return resolveCache.get(key) ?? [];
+          const resolved = resolveTargetCandidates(deps.db, key);
+          resolveCache.set(key, resolved);
+          return resolved;
+        };
+
+        for (const rel of AILSS_TYPED_LINK_KEYS) {
+          const current = frontmatter[rel];
+
+          if (typeof current === "string") {
+            const { target_for_resolution, display_for_canonical_link } =
+              splitTargetAndDisplay(current);
+            if (!target_for_resolution) continue;
+
+            const resolved = resolveCached(target_for_resolution);
+            if (resolved.length === 1) {
+              const canonicalTarget = removeMarkdownExtension(resolved[0]!.path);
+              const after = canonicalWikilink(canonicalTarget, display_for_canonical_link);
+              if (after !== current) {
+                nextFrontmatter[rel] = after;
+                edits.push({
+                  rel,
+                  index: 0,
+                  before: current,
+                  after,
+                  target_before: target_for_resolution,
+                  target_after: canonicalTarget,
+                });
+              }
+              continue;
+            }
+
+            if (resolved.length === 0) {
+              unresolved.push({
+                rel,
+                index: 0,
+                before: current,
+                target: target_for_resolution,
+              });
+              continue;
+            }
+
+            ambiguous.push({
+              rel,
+              index: 0,
+              before: current,
+              target: target_for_resolution,
+              candidates: resolved.slice(0, MAX_REPORTED_CANDIDATES).map((candidate) => ({
+                path: candidate.path,
+                title: candidate.title,
+                matched_by: candidate.matchedBy,
+              })),
+            });
+            continue;
+          }
+
+          if (!Array.isArray(current)) continue;
+
+          const nextArray = [...current];
+          let arrayChanged = false;
+
+          for (const [index, entry] of current.entries()) {
+            if (typeof entry !== "string") continue;
+
+            const { target_for_resolution, display_for_canonical_link } =
+              splitTargetAndDisplay(entry);
+            if (!target_for_resolution) continue;
+
+            const resolved = resolveCached(target_for_resolution);
+            if (resolved.length === 1) {
+              const canonicalTarget = removeMarkdownExtension(resolved[0]!.path);
+              const after = canonicalWikilink(canonicalTarget, display_for_canonical_link);
+              if (after !== entry) {
+                nextArray[index] = after;
+                arrayChanged = true;
+                edits.push({
+                  rel,
+                  index,
+                  before: entry,
+                  after,
+                  target_before: target_for_resolution,
+                  target_after: canonicalTarget,
+                });
+              }
+              continue;
+            }
+
+            if (resolved.length === 0) {
+              unresolved.push({
+                rel,
+                index,
+                before: entry,
+                target: target_for_resolution,
+              });
+              continue;
+            }
+
+            ambiguous.push({
+              rel,
+              index,
+              before: entry,
+              target: target_for_resolution,
+              candidates: resolved.slice(0, MAX_REPORTED_CANDIDATES).map((candidate) => ({
+                path: candidate.path,
+                title: candidate.title,
+                matched_by: candidate.matchedBy,
+              })),
+            });
+          }
+
+          if (arrayChanged) {
+            nextFrontmatter[rel] = nextArray;
+          }
+        }
+
+        let afterText = beforeText;
+        if (edits.length > 0 && split) {
+          afterText = renderMarkdownWithFrontmatter(nextFrontmatter, split.body);
+        }
+
+        const afterSha256 = sha256HexUtf8(afterText);
+        const changed = afterSha256 !== beforeSha256;
+
+        let reindexed = false;
+        let reindexSummary: {
+          changed_files: number;
+          indexed_chunks: number;
+          deleted_files: number;
+        } | null = null;
+        let reindexError: string | null = null;
+
+        if (args.apply && changed) {
+          await writeVaultFileText({ vaultPath, vaultRelPath: args.path, text: afterText });
+
+          if (args.reindex_after_apply) {
+            try {
+              const summary = await reindexVaultPaths(deps, [args.path]);
+              reindexed = true;
+              reindexSummary = {
+                changed_files: summary.changedFiles,
+                indexed_chunks: summary.indexedChunks,
+                deleted_files: summary.deletedFiles,
+              };
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              reindexError = message;
+            }
+          }
+        }
+
+        const payload = {
+          path: args.path,
+          applied: Boolean(args.apply && changed),
+          changed,
+          before_sha256: beforeSha256,
+          after_sha256: afterSha256,
+          edits,
+          unresolved,
+          ambiguous,
+          needs_reindex: Boolean(args.apply && changed && !reindexed),
+          reindexed,
+          reindex_summary: reindexSummary,
+          reindex_error: reindexError,
+        };
+
+        return {
+          structuredContent: payload,
+          content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+        };
+      };
+
+      if (args.apply) {
+        return await (deps.writeLock ? deps.writeLock.runExclusive(run) : run());
+      }
+
+      return await run();
+    },
+  );
+}

--- a/packages/mcp/src/tools/canonicalizeTypedLinks.ts
+++ b/packages/mcp/src/tools/canonicalizeTypedLinks.ts
@@ -125,25 +125,18 @@ function splitTargetAndDisplay(raw: string): {
     };
   }
 
-  if (trimmed.startsWith("[[") && trimmed.endsWith("]]")) {
-    const inner = trimmed.slice(2, -2).trim();
-    const pipeIndex = inner.indexOf("|");
-    const left = (pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner).trim();
-    const right = (pipeIndex >= 0 ? inner.slice(pipeIndex + 1) : "").trim();
-    const targetForResolution = left.split("#")[0]?.trim() ?? "";
-    const displayForCanonicalLink = right || left || inner;
+  const inner =
+    trimmed.startsWith("[[") && trimmed.endsWith("]]") ? trimmed.slice(2, -2).trim() : trimmed;
 
-    return {
-      target_for_resolution: targetForResolution || left || inner,
-      display_for_canonical_link: displayForCanonicalLink,
-    };
-  }
+  const pipeIndex = inner.indexOf("|");
+  const left = (pipeIndex >= 0 ? inner.slice(0, pipeIndex) : inner).trim();
+  const right = (pipeIndex >= 0 ? inner.slice(pipeIndex + 1) : "").trim();
+  const targetForResolution = left.split("#")[0]?.trim() ?? "";
+  const displayForCanonicalLink = right || left || inner;
 
-  const targetWithoutDisplay = trimmed.split("|")[0]?.trim() ?? "";
-  const targetForResolution = targetWithoutDisplay.split("#")[0]?.trim() ?? "";
   return {
-    target_for_resolution: targetForResolution || trimmed,
-    display_for_canonical_link: trimmed,
+    target_for_resolution: targetForResolution || left || inner,
+    display_for_canonical_link: displayForCanonicalLink,
   };
 }
 

--- a/packages/mcp/test/httpTools.writeTools.test.ts
+++ b/packages/mcp/test/httpTools.writeTools.test.ts
@@ -339,6 +339,7 @@ describe("MCP HTTP server (write tools)", () => {
           '  - "[[Missing]]"',
           '  - "[[Nested/Note]]"',
           'uses: "[[Deterministic|Shown]]"',
+          'summarizes: "Deterministic|Alias Plain"',
           "---",
           "",
           "Body should stay exactly here.",
@@ -400,7 +401,7 @@ describe("MCP HTTP server (write tools)", () => {
 
           const editsRaw = dryStructured["edits"];
           assertArray(editsRaw, "canonicalize_typed_links.edits");
-          expect(editsRaw).toHaveLength(3);
+          expect(editsRaw).toHaveLength(4);
 
           const afterValues = editsRaw
             .map((entry) => {
@@ -410,6 +411,7 @@ describe("MCP HTTP server (write tools)", () => {
             .sort();
           expect(afterValues).toEqual([
             "[[Folder/Strict|Strict Label]]",
+            "[[Topics/Deterministic|Alias Plain]]",
             "[[Topics/Deterministic|Deterministic]]",
             "[[Topics/Deterministic|Shown]]",
           ]);
@@ -459,6 +461,7 @@ describe("MCP HTTP server (write tools)", () => {
             "[[Nested/Note]]",
           ]);
           expect(parsed.frontmatter.uses).toBe("[[Topics/Deterministic|Shown]]");
+          expect(parsed.frontmatter.summarizes).toBe("[[Topics/Deterministic|Alias Plain]]");
         },
       );
     });


### PR DESCRIPTION
## What

- add a new MCP write tool `canonicalize_typed_links` for single-note frontmatter typed-link canonicalization
- register the tool behind the existing write-tools gate (`AILSS_ENABLE_WRITE_TOOLS=1`)
- implement deterministic dry-run output with `edits`, `unresolved`, and `ambiguous` result sets
- add strict path resolution for targets containing `/` (exact vault-relative path match only)
- add/extend tests and sync MCP tool documentation

## Why

- issue #61 requires an ergonomic fix path for ambiguous typed-link targets, not only reporting
- canonical path rewrites reduce future ambiguity and keep typed-link targets deterministic
- Fixes #61

## How

- parse one note’s frontmatter typed-link keys and evaluate each typed-link target without touching note body links
- rewrite only uniquely resolved targets to `[[<vault-relative-path-without-.md>|<original display or target>]]`
- keep unresolved/ambiguous targets unchanged and return candidates for ambiguous cases
- validate with full repository checks via pre-push (`pnpm check`: format, lint, typecheck, tests)
- update docs: `README.md`, `docs/01-overview.md`, `docs/03-plan.md`, `docs/reference/mcp-tools.md`, `docs/ops/codex-skills/prometheus-agent/SKILL.md`
