### PR TITLE
feat: increase default AILSS_MCP_HTTP_MAX_SESSIONS to 50

### DIFF
--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -307,7 +307,7 @@ Status (implemented):
 
 - Implemented in `packages/mcp/src/httpServer.ts` using a session manager that creates one server + transport per `initialize`.
 - Defaults:
-  - `AILSS_MCP_HTTP_MAX_SESSIONS=20`
+  - `AILSS_MCP_HTTP_MAX_SESSIONS=50`
   - `AILSS_MCP_HTTP_IDLE_TTL_MS=3600000` (1 hour)
   - `AILSS_MCP_HTTP_SHUTDOWN_TOKEN=<token>` (optional; enables `POST /__ailss/shutdown`; use a separate admin token)
 

--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -176,9 +176,9 @@ function getSingleHeaderValue(req: IncomingMessage, name: string): string | null
 }
 
 function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "20").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "50").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 20;
+  if (!Number.isFinite(n) || n < 1) return 50;
   return n;
 }
 

--- a/packages/mcp/test/httpSessions.defaultMaxSessions.test.ts
+++ b/packages/mcp/test/httpSessions.defaultMaxSessions.test.ts
@@ -1,0 +1,63 @@
+import { describe, it } from "vitest";
+
+import path from "node:path";
+
+import { createAilssMcpRuntimeFromEnv } from "../src/createAilssMcpServer.js";
+import { startAilssMcpHttpServer } from "../src/httpServer.js";
+
+import {
+  mcpInitialize,
+  mcpToolsList,
+  mcpToolsListExpectSessionNotFound,
+  withEnv,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+describe("MCP HTTP server (default max sessions)", () => {
+  it("uses 50 as the default max session cap when env override is missing", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withEnv(
+        {
+          OPENAI_API_KEY: "test",
+          OPENAI_EMBEDDING_MODEL: "text-embedding-3-large",
+          AILSS_DB_PATH: dbPath,
+          AILSS_VAULT_PATH: "",
+          AILSS_ENABLE_WRITE_TOOLS: "",
+          AILSS_MCP_HTTP_MAX_SESSIONS: "",
+        },
+        async () => {
+          const runtime = await createAilssMcpRuntimeFromEnv();
+          const token = "test-token";
+          const { close, url } = await startAilssMcpHttpServer({
+            runtime,
+            config: { host: "127.0.0.1", port: 0, path: "/mcp", token },
+            idleTtlMs: 60_000,
+          });
+
+          try {
+            const sessions: string[] = [];
+
+            for (let i = 0; i < 21; i++) {
+              sessions.push(await mcpInitialize(url, token, `client-${i}`));
+            }
+
+            await mcpToolsList(url, token, sessions[0]!);
+            await mcpToolsList(url, token, sessions[20]!);
+
+            for (let i = 21; i < 51; i++) {
+              sessions.push(await mcpInitialize(url, token, `client-${i}`));
+            }
+
+            await mcpToolsListExpectSessionNotFound(url, token, sessions[1]!);
+            await mcpToolsList(url, token, sessions[50]!);
+          } finally {
+            await close();
+            runtime.deps.db.close();
+          }
+        },
+      );
+    });
+  });
+});

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -16,7 +16,8 @@ type EnvKey =
   | "OPENAI_EMBEDDING_MODEL"
   | "AILSS_DB_PATH"
   | "AILSS_VAULT_PATH"
-  | "AILSS_ENABLE_WRITE_TOOLS";
+  | "AILSS_ENABLE_WRITE_TOOLS"
+  | "AILSS_MCP_HTTP_MAX_SESSIONS";
 
 export type EnvOverrides = Partial<Record<EnvKey, string | undefined>>;
 


### PR DESCRIPTION
## What

- Increase the MCP HTTP default session cap from `20` to `50`.
- Add a regression test that verifies the effective default cap behavior (`50`) when no env override is provided.
- Update `docs/03-plan.md` to reflect the new default.

## Why

- Long-lived concurrent Codex usage can exceed `20` active sessions and trigger avoidable session eviction (`Session not found` / HTTP 404).
- Raising the default cap reduces eviction pressure without changing explicit env override behavior.
- Fixes #74

## How

- Changed `parseMaxSessionsFromEnv()` fallback/default values in `packages/mcp/src/httpServer.ts` from `20` to `50`.
- Added `packages/mcp/test/httpSessions.defaultMaxSessions.test.ts` to assert:
  - no early eviction before 50 sessions
  - eviction starts once session count exceeds 50
- Extended test env helper key set in `packages/mcp/test/httpTestUtils.ts` for `AILSS_MCP_HTTP_MAX_SESSIONS`.
