### PR TITLE
feat: add optional neo4j hybrid graph integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,12 @@ OPENAI_EMBEDDING_MODEL=text-embedding-3-large
 AILSS_VAULT_PATH=/absolute/path/to/your/Obsidian/AILSS
 # Optional (MCP only): DB path override when AILSS_VAULT_PATH is not set
 # AILSS_DB_PATH=/absolute/path/to/your/index.sqlite
+
+# Optional Neo4j hybrid graph mirror
+# AILSS_NEO4J_ENABLED=1
+# AILSS_NEO4J_URI=bolt://127.0.0.1:7687
+# AILSS_NEO4J_USERNAME=neo4j
+# AILSS_NEO4J_PASSWORD=your_password
+# AILSS_NEO4J_DATABASE=neo4j
+# AILSS_NEO4J_SYNC_ON_INDEX=1
+# AILSS_NEO4J_STRICT_MODE=0

--- a/README.md
+++ b/README.md
@@ -77,9 +77,14 @@ Full rules: `docs/standards/vault/README.md`.
 
 Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 
-- Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`
+- Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`, `neo4j_graph_status`, `neo4j_graph_traverse`
 - Write tools (gated): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`  
   Requires `AILSS_ENABLE_WRITE_TOOLS=1` and `apply=true`.
+
+Optional Neo4j hybrid mode:
+
+- Keep SQLite as source of truth, and mirror `notes` + `typed_links` to Neo4j after indexing.
+- Enable with `AILSS_NEO4J_ENABLED=1` plus `AILSS_NEO4J_URI`, `AILSS_NEO4J_USERNAME`, `AILSS_NEO4J_PASSWORD` (optional `AILSS_NEO4J_DATABASE`, default: `neo4j`).
 
 ## Docs
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -65,10 +65,11 @@ Frontmatter query support (current):
 
 - AILSS stores normalized frontmatter in SQLite for retrieval and graph building.
 - Optional Neo4j hybrid mode mirrors `notes` + `typed_links` into Neo4j without replacing SQLite as source of truth.
+  - Mirror sync is staged by `run_id` and switched via an active pointer only after consistency checks pass.
 - The MCP surface supports both:
   - semantic retrieval via `get_context`
   - metadata filtering via `search_notes` + typed-link navigation/backrefs via `expand_typed_links_outgoing` / `find_typed_links_incoming`
-  - graph-native checks/traversal via `neo4j_graph_status` / `neo4j_graph_traverse`
+  - graph-native checks/traversal via `neo4j_graph_status` / `neo4j_graph_traverse` (auto fallback to SQLite when Neo4j is unavailable or inconsistent)
 
 Read-first tools (planned):
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -43,6 +43,8 @@ Read-first tools (implemented in this repo):
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `neo4j_graph_status`: report optional Neo4j mirror availability and SQLite↔Neo4j consistency
+- `neo4j_graph_traverse`: multi-hop traversal over the optional Neo4j graph mirror (falls back to SQLite outgoing traversal if unavailable)
 
 Client guidance (Codex):
 
@@ -62,9 +64,11 @@ Transport / client integration:
 Frontmatter query support (current):
 
 - AILSS stores normalized frontmatter in SQLite for retrieval and graph building.
+- Optional Neo4j hybrid mode mirrors `notes` + `typed_links` into Neo4j without replacing SQLite as source of truth.
 - The MCP surface supports both:
   - semantic retrieval via `get_context`
   - metadata filtering via `search_notes` + typed-link navigation/backrefs via `expand_typed_links_outgoing` / `find_typed_links_incoming`
+  - graph-native checks/traversal via `neo4j_graph_status` / `neo4j_graph_traverse`
 
 Read-first tools (planned):
 
@@ -85,6 +89,13 @@ TBD
 Write tools are gated and not exposed by default:
 
 - Set `AILSS_ENABLE_WRITE_TOOLS=1` to register write tools like `edit_note` in the MCP server
+
+Optional Neo4j hybrid config:
+
+- `AILSS_NEO4J_ENABLED=1`: enable Neo4j integration
+- `AILSS_NEO4J_URI`, `AILSS_NEO4J_USERNAME`, `AILSS_NEO4J_PASSWORD`, `AILSS_NEO4J_DATABASE`: Neo4j connection settings
+- `AILSS_NEO4J_SYNC_ON_INDEX=1` (default): sync SQLite graph to Neo4j after indexer runs
+- `AILSS_NEO4J_STRICT_MODE=1`: fail hard if Neo4j sync/connectivity fails (default is best-effort fallback)
 
 ## 3) Obsidian plugin
 

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,9 +24,13 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-  - Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+  - Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`, `neo4j_graph_status`, `neo4j_graph_traverse`
   - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
+- Optional Neo4j hybrid graph mirror (phase 1):
+  - SQLite remains source of truth
+  - Indexer can sync `notes`/`typed_links` into Neo4j
+  - MCP provides read-only Neo4j status/traversal with SQLite fallback when unavailable
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
   - UI: status modals for indexing and the localhost MCP service
   - Indexing: `AILSS: Reindex vault` command + optional auto-index on file changes (debounced; spawns the indexer process)
@@ -130,6 +134,8 @@ Implemented:
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `neo4j_graph_status`: report optional Neo4j mirror availability and SQLite↔Neo4j consistency
+- `neo4j_graph_traverse`: multi-hop traversal over optional Neo4j mirror (with SQLite fallback)
 
 Notes on queryability (current):
 

--- a/docs/architecture/data-db.md
+++ b/docs/architecture/data-db.md
@@ -77,6 +77,16 @@ Example `to_wikilink` value:
 [[WorldAce]]
 ```
 
+## Optional Neo4j hybrid mirror (phase 1)
+
+- SQLite remains the source of truth for indexing/retrieval.
+- When enabled, the indexer mirrors graph structures into Neo4j after indexing:
+  - `(:AilssNote {path})` from SQLite `notes`
+  - `(:AilssTarget {target})` from SQLite `typed_links.to_target`
+  - `(:AilssNote)-[:AILSS_TYPED_LINK]->(:AilssTarget)` (one edge per SQLite `typed_links` row)
+  - `(:AilssTarget)-[:AILSS_RESOLVES_TO]->(:AilssNote)` (derived target resolution links)
+- MCP read tools can query Neo4j (`neo4j_graph_status`, `neo4j_graph_traverse`) and fall back safely when Neo4j is disabled/unavailable.
+
 ## Query support (current)
 
 - Metadata filtering supports only a fixed set of filters backed by indexed columns/tables:

--- a/docs/ops/local-dev.md
+++ b/docs/ops/local-dev.md
@@ -10,6 +10,12 @@ Create a `.env` at the repo root based on `.env.example`, and set:
 - `AILSS_VAULT_PATH` (absolute path)
 - `OPENAI_EMBEDDING_MODEL` (optional; default: `text-embedding-3-large`)
 - `AILSS_DB_PATH` (optional; MCP only): absolute path to an existing DB file when `AILSS_VAULT_PATH` is not set
+- Optional Neo4j hybrid mode:
+  - `AILSS_NEO4J_ENABLED=1`
+  - `AILSS_NEO4J_URI`, `AILSS_NEO4J_USERNAME`, `AILSS_NEO4J_PASSWORD`
+  - `AILSS_NEO4J_DATABASE` (optional; default: `neo4j`)
+  - `AILSS_NEO4J_SYNC_ON_INDEX` (optional; default: `1`)
+  - `AILSS_NEO4J_STRICT_MODE` (optional; default: `0`)
 
 Notes:
 
@@ -43,6 +49,7 @@ Options:
 Note:
 
 - The index DB records the embedding model/dimension and refuses to start on mismatch. Use `--reset-db` (or a different `--db` path) when switching models.
+- If Neo4j hybrid mode is enabled, indexer also syncs SQLite `notes`/`typed_links` into Neo4j after each run.
 
 ## 4) Run MCP server (STDIO)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -113,6 +113,7 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 - Input: none
 - Notes:
   - Always available as a read tool.
+  - Includes mirror metadata: `active_run_id`, `mirror_status`, `last_success_at`, `last_error`, `last_error_at`.
   - When Neo4j is disabled/unavailable, returns non-fatal fallback status (`available=false`) with SQLite counts.
 
 ### `neo4j_graph_traverse`
@@ -128,6 +129,7 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `include_unresolved_targets` (boolean, default: `false`)
 - Notes:
   - When Neo4j is unavailable, tool falls back to SQLite-based outgoing traversal and reports `backend="sqlite_fallback"`.
+  - When Neo4j is reachable but mirror counts are inconsistent with SQLite, it also falls back to SQLite and reports the inconsistency reason.
   - Fallback mode supports outgoing traversal semantics only.
 
 ## Write tools (gated)

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -107,6 +107,29 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 - Input:
   - `limit` (int, default: `200`, range: `1–5000`)
 
+### `neo4j_graph_status`
+
+- Purpose: report optional Neo4j graph mirror availability and SQLite↔Neo4j consistency status.
+- Input: none
+- Notes:
+  - Always available as a read tool.
+  - When Neo4j is disabled/unavailable, returns non-fatal fallback status (`available=false`) with SQLite counts.
+
+### `neo4j_graph_traverse`
+
+- Purpose: multi-hop traversal over the optional Neo4j graph mirror.
+- Input:
+  - `path` (string, required; vault-relative seed note path)
+  - `direction` (`"outgoing" | "incoming" | "both"`, default: `"both"`)
+  - `max_hops` (int, default: `2`, range: `1–6`)
+  - `max_notes` (int, default: `80`, range: `1–400`)
+  - `max_edges` (int, default: `1500`, range: `1–10,000`)
+  - `max_links_per_note` (int, default: `80`, range: `1–500`)
+  - `include_unresolved_targets` (boolean, default: `false`)
+- Notes:
+  - When Neo4j is unavailable, tool falls back to SQLite-based outgoing traversal and reports `backend="sqlite_fallback"`.
+  - Fallback mode supports outgoing traversal semantics only.
+
 ## Write tools (gated)
 
 Write tools are registered only when `AILSS_ENABLE_WRITE_TOOLS=1` and they only write when `apply=true`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,7 @@
     "better-sqlite3": "^12.4.1",
     "dotenv": "^17.2.2",
     "gray-matter": "^4.0.3",
+    "neo4j-driver": "^5.28.2",
     "sqlite-vec": "0.1.7-alpha.2"
   }
 }

--- a/packages/core/src/db/queries.ts
+++ b/packages/core/src/db/queries.ts
@@ -632,6 +632,82 @@ export function listKeywords(db: AilssDb, options: { limit?: number } = {}): Key
   return rows;
 }
 
+export type SqliteGraphCounts = {
+  notes: number;
+  typedLinks: number;
+};
+
+export function getSqliteGraphCounts(db: AilssDb): SqliteGraphCounts {
+  const noteRow = db.prepare(`SELECT COUNT(*) AS count FROM notes`).get() as { count: number };
+  const typedLinkRow = db.prepare(`SELECT COUNT(*) AS count FROM typed_links`).get() as {
+    count: number;
+  };
+  return {
+    notes: noteRow.count ?? 0,
+    typedLinks: typedLinkRow.count ?? 0,
+  };
+}
+
+export type GraphSyncNoteRow = {
+  path: string;
+  noteId: string | null;
+  created: string | null;
+  title: string | null;
+  summary: string | null;
+  entity: string | null;
+  layer: string | null;
+  status: string | null;
+  updated: string | null;
+};
+
+export function listNotesForGraphSync(db: AilssDb): GraphSyncNoteRow[] {
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          path,
+          note_id AS noteId,
+          created,
+          title,
+          summary,
+          entity,
+          layer,
+          status,
+          updated
+        FROM notes
+        ORDER BY path
+      `,
+    )
+    .all() as GraphSyncNoteRow[];
+  return rows;
+}
+
+export type GraphSyncTypedLinkRow = {
+  fromPath: string;
+  rel: string;
+  toTarget: string;
+  toWikilink: string;
+  position: number;
+};
+
+export function listTypedLinksForGraphSync(db: AilssDb): GraphSyncTypedLinkRow[] {
+  const rows = db
+    .prepare(
+      `
+        SELECT
+          from_path AS fromPath,
+          rel,
+          to_target AS toTarget,
+          to_wikilink AS toWikilink,
+          position
+        FROM typed_links
+        ORDER BY from_path, position, rel, to_target
+      `,
+    )
+    .all() as GraphSyncTypedLinkRow[];
+  return rows;
+}
+
 export type TypedLinkQuery = {
   rel?: string;
   toTarget?: string;

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -10,6 +10,13 @@ export type AilssEnv = {
   openaiEmbeddingModel: string;
   enableWriteTools: boolean;
   vaultPath: string | undefined;
+  neo4jEnabled: boolean;
+  neo4jUri: string | undefined;
+  neo4jUsername: string | undefined;
+  neo4jPassword: string | undefined;
+  neo4jDatabase: string;
+  neo4jSyncOnIndex: boolean;
+  neo4jStrictMode: boolean;
 };
 
 function findNearestEnvFile(startDir: string): string | null {
@@ -42,5 +49,12 @@ export function loadEnv(): AilssEnv {
     openaiEmbeddingModel: process.env.OPENAI_EMBEDDING_MODEL ?? "text-embedding-3-large",
     enableWriteTools: process.env.AILSS_ENABLE_WRITE_TOOLS === "1",
     vaultPath: process.env.AILSS_VAULT_PATH,
+    neo4jEnabled: process.env.AILSS_NEO4J_ENABLED === "1",
+    neo4jUri: process.env.AILSS_NEO4J_URI,
+    neo4jUsername: process.env.AILSS_NEO4J_USERNAME,
+    neo4jPassword: process.env.AILSS_NEO4J_PASSWORD,
+    neo4jDatabase: process.env.AILSS_NEO4J_DATABASE ?? "neo4j",
+    neo4jSyncOnIndex: process.env.AILSS_NEO4J_SYNC_ON_INDEX !== "0",
+    neo4jStrictMode: process.env.AILSS_NEO4J_STRICT_MODE === "1",
   };
 }

--- a/packages/core/src/graph/neo4j.ts
+++ b/packages/core/src/graph/neo4j.ts
@@ -1,0 +1,590 @@
+// Neo4j graph sync and query helpers
+// - optional SQLite -> Neo4j hybrid integration
+
+import neo4j from "neo4j-driver";
+import type { Driver, Session } from "neo4j-driver";
+
+import {
+  getSqliteGraphCounts,
+  listNotesForGraphSync,
+  listTypedLinksForGraphSync,
+  resolveNotePathsByWikilinkTarget,
+  type AilssDb,
+} from "../db/db.js";
+import type { AilssEnv } from "../env.js";
+
+export type Neo4jConnectionConfig = {
+  uri: string;
+  username: string;
+  password: string;
+  database: string;
+};
+
+export type Neo4jSettings = {
+  enabled: boolean;
+  syncOnIndex: boolean;
+  strictMode: boolean;
+  config: Neo4jConnectionConfig | null;
+  unavailableReason: string | null;
+};
+
+function nonEmptyOrNull(value: string | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed ? trimmed : null;
+}
+
+export function resolveNeo4jSettings(
+  env: Pick<
+    AilssEnv,
+    | "neo4jEnabled"
+    | "neo4jUri"
+    | "neo4jUsername"
+    | "neo4jPassword"
+    | "neo4jDatabase"
+    | "neo4jSyncOnIndex"
+    | "neo4jStrictMode"
+  >,
+): Neo4jSettings {
+  if (!env.neo4jEnabled) {
+    return {
+      enabled: false,
+      syncOnIndex: env.neo4jSyncOnIndex,
+      strictMode: env.neo4jStrictMode,
+      config: null,
+      unavailableReason: "Neo4j integration disabled. Set AILSS_NEO4J_ENABLED=1 to enable it.",
+    };
+  }
+
+  const uri = nonEmptyOrNull(env.neo4jUri);
+  const username = nonEmptyOrNull(env.neo4jUsername);
+  const password = nonEmptyOrNull(env.neo4jPassword);
+  const database = nonEmptyOrNull(env.neo4jDatabase) ?? "neo4j";
+
+  if (!uri || !username || !password) {
+    return {
+      enabled: true,
+      syncOnIndex: env.neo4jSyncOnIndex,
+      strictMode: env.neo4jStrictMode,
+      config: null,
+      unavailableReason:
+        "Neo4j enabled but not fully configured. Set AILSS_NEO4J_URI, AILSS_NEO4J_USERNAME, and AILSS_NEO4J_PASSWORD.",
+    };
+  }
+
+  return {
+    enabled: true,
+    syncOnIndex: env.neo4jSyncOnIndex,
+    strictMode: env.neo4jStrictMode,
+    config: { uri, username, password, database },
+    unavailableReason: null,
+  };
+}
+
+function createNeo4jDriver(config: Neo4jConnectionConfig): Driver {
+  return neo4j.driver(
+    config.uri,
+    neo4j.auth.basic(config.username, config.password),
+    // Lossless integer mode
+    { disableLosslessIntegers: false },
+  );
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (neo4j.isInt(value)) {
+    return value.inSafeRange() ? value.toNumber() : Number.parseInt(value.toString(), 10);
+  }
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function chunked<T>(items: T[], size: number): T[][] {
+  if (items.length === 0) return [];
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+async function runBatchWrites<T extends Record<string, unknown>>(
+  session: Session,
+  query: string,
+  rows: T[],
+  batchSize: number,
+): Promise<void> {
+  if (rows.length === 0) return;
+  for (const batch of chunked(rows, batchSize)) {
+    await session.executeWrite((tx) => tx.run(query, { rows: batch }));
+  }
+}
+
+export type Neo4jGraphCounts = {
+  notes: number;
+  typedLinks: number;
+  targets: number;
+  resolvedLinks: number;
+};
+
+async function readNeo4jGraphCounts(session: Session): Promise<Neo4jGraphCounts> {
+  const result = await session.executeRead((tx) =>
+    tx.run(`
+      CALL {
+        MATCH (n:AilssNote)
+        RETURN count(n) AS notes
+      }
+      CALL {
+        MATCH ()-[r:AILSS_TYPED_LINK]->()
+        RETURN count(r) AS typedLinks
+      }
+      CALL {
+        MATCH (t:AilssTarget)
+        RETURN count(t) AS targets
+      }
+      CALL {
+        MATCH ()-[r:AILSS_RESOLVES_TO]->()
+        RETURN count(r) AS resolvedLinks
+      }
+      RETURN notes, typedLinks, targets, resolvedLinks
+    `),
+  );
+
+  const row = result.records[0];
+  if (!row) {
+    return { notes: 0, typedLinks: 0, targets: 0, resolvedLinks: 0 };
+  }
+
+  return {
+    notes: toNumber(row.get("notes")),
+    typedLinks: toNumber(row.get("typedLinks")),
+    targets: toNumber(row.get("targets")),
+    resolvedLinks: toNumber(row.get("resolvedLinks")),
+  };
+}
+
+export type Neo4jSyncSummary = {
+  sqliteCounts: {
+    notes: number;
+    typedLinks: number;
+  };
+  neo4jCounts: Neo4jGraphCounts;
+  consistent: boolean;
+};
+
+export type SyncSqliteGraphToNeo4jOptions = {
+  batchSize?: number;
+  maxResolutionsPerTarget?: number;
+};
+
+const UPSERT_NOTES_CYPHER = `
+  UNWIND $rows AS row
+  MERGE (n:AilssNote { path: row.path })
+  SET
+    n.note_id = row.noteId,
+    n.created = row.created,
+    n.title = row.title,
+    n.summary = row.summary,
+    n.entity = row.entity,
+    n.layer = row.layer,
+    n.status = row.status,
+    n.updated = row.updated
+`;
+
+const UPSERT_TARGETS_CYPHER = `
+  UNWIND $rows AS row
+  MERGE (t:AilssTarget { target: row.target })
+`;
+
+const INSERT_TYPED_LINKS_CYPHER = `
+  UNWIND $rows AS row
+  MATCH (from:AilssNote { path: row.fromPath })
+  MATCH (target:AilssTarget { target: row.target })
+  CREATE (from)-[:AILSS_TYPED_LINK {
+    edge_key: row.edgeKey,
+    rel: row.rel,
+    to_wikilink: row.toWikilink,
+    position: row.position
+  }]->(target)
+`;
+
+const UPSERT_RESOLVED_LINKS_CYPHER = `
+  UNWIND $rows AS row
+  MATCH (target:AilssTarget { target: row.target })
+  MATCH (to:AilssNote { path: row.toPath })
+  MERGE (target)-[r:AILSS_RESOLVES_TO { to_path: row.toPath }]->(to)
+  SET r.matched_by = row.matchedBy
+`;
+
+export async function syncSqliteGraphToNeo4j(
+  db: AilssDb,
+  config: Neo4jConnectionConfig,
+  options: SyncSqliteGraphToNeo4jOptions = {},
+): Promise<Neo4jSyncSummary> {
+  const sqliteCounts = getSqliteGraphCounts(db);
+  const notes = listNotesForGraphSync(db);
+  const typedLinks = listTypedLinksForGraphSync(db);
+
+  const batchSize = Math.min(Math.max(1, options.batchSize ?? 500), 2000);
+  const maxResolutionsPerTarget = Math.min(Math.max(1, options.maxResolutionsPerTarget ?? 20), 200);
+
+  const targets = Array.from(new Set(typedLinks.map((link) => link.toTarget))).sort((a, b) =>
+    a.localeCompare(b),
+  );
+  const targetRows = targets.map((target) => ({ target }));
+
+  const typedLinkRows = typedLinks.map((link, index) => ({
+    edgeKey: `${index}:${link.fromPath}:${link.rel}:${link.toTarget}:${link.position}`,
+    fromPath: link.fromPath,
+    rel: link.rel,
+    target: link.toTarget,
+    toWikilink: link.toWikilink,
+    position: link.position,
+  }));
+
+  const resolvedRows: Array<{ target: string; toPath: string; matchedBy: string }> = [];
+  for (const target of targets) {
+    const matches = resolveNotePathsByWikilinkTarget(db, target, maxResolutionsPerTarget);
+    for (const match of matches) {
+      resolvedRows.push({
+        target,
+        toPath: match.path,
+        matchedBy: match.matchedBy,
+      });
+    }
+  }
+
+  const driver = createNeo4jDriver(config);
+  try {
+    await driver.verifyConnectivity();
+    const session = driver.session({
+      database: config.database,
+      defaultAccessMode: neo4j.session.WRITE,
+    });
+    try {
+      await session.executeWrite((tx) =>
+        tx.run(
+          "CREATE CONSTRAINT ailss_note_path_unique IF NOT EXISTS FOR (n:AilssNote) REQUIRE n.path IS UNIQUE",
+        ),
+      );
+      await session.executeWrite((tx) =>
+        tx.run(
+          "CREATE CONSTRAINT ailss_target_value_unique IF NOT EXISTS FOR (t:AilssTarget) REQUIRE t.target IS UNIQUE",
+        ),
+      );
+
+      // Full mirror refresh
+      await session.executeWrite((tx) => tx.run("MATCH (n:AilssNote) DETACH DELETE n"));
+      await session.executeWrite((tx) => tx.run("MATCH (t:AilssTarget) DETACH DELETE t"));
+
+      await runBatchWrites(session, UPSERT_NOTES_CYPHER, notes, batchSize);
+      await runBatchWrites(session, UPSERT_TARGETS_CYPHER, targetRows, batchSize);
+      await runBatchWrites(session, INSERT_TYPED_LINKS_CYPHER, typedLinkRows, batchSize);
+      await runBatchWrites(session, UPSERT_RESOLVED_LINKS_CYPHER, resolvedRows, batchSize);
+
+      const neo4jCounts = await readNeo4jGraphCounts(session);
+      const consistent =
+        sqliteCounts.notes === neo4jCounts.notes &&
+        sqliteCounts.typedLinks === neo4jCounts.typedLinks;
+
+      return { sqliteCounts, neo4jCounts, consistent };
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await driver.close();
+  }
+}
+
+export async function readNeo4jGraphStatus(
+  db: AilssDb,
+  config: Neo4jConnectionConfig,
+): Promise<Neo4jSyncSummary> {
+  const sqliteCounts = getSqliteGraphCounts(db);
+  const driver = createNeo4jDriver(config);
+  try {
+    await driver.verifyConnectivity();
+    const session = driver.session({
+      database: config.database,
+      defaultAccessMode: neo4j.session.READ,
+    });
+    try {
+      const neo4jCounts = await readNeo4jGraphCounts(session);
+      const consistent =
+        sqliteCounts.notes === neo4jCounts.notes &&
+        sqliteCounts.typedLinks === neo4jCounts.typedLinks;
+      return { sqliteCounts, neo4jCounts, consistent };
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await driver.close();
+  }
+}
+
+export type Neo4jTraversalDirection = "outgoing" | "incoming" | "both";
+
+export type Neo4jTraversalNode = {
+  path: string;
+  hop: number;
+};
+
+export type Neo4jTraversalEdge = {
+  direction: "outgoing" | "incoming";
+  fromPath: string;
+  toPath: string | null;
+  rel: string;
+  target: string;
+  toWikilink: string;
+};
+
+export type Neo4jTraversalResult = {
+  nodes: Neo4jTraversalNode[];
+  edges: Neo4jTraversalEdge[];
+  truncated: boolean;
+};
+
+export type TraverseNeo4jGraphOptions = {
+  path: string;
+  direction?: Neo4jTraversalDirection;
+  maxHops?: number;
+  maxNotes?: number;
+  maxEdges?: number;
+  maxLinksPerNote?: number;
+  includeUnresolvedTargets?: boolean;
+};
+
+type RawTraversalRow = {
+  fromPath: string;
+  toPath: string | null;
+  rel: string;
+  target: string;
+  toWikilink: string;
+};
+
+function toStringOrEmpty(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function toNullableString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+async function queryOutgoingRows(
+  session: Session,
+  path: string,
+  limit: number,
+): Promise<RawTraversalRow[]> {
+  const result = await session.executeRead((tx) =>
+    tx.run(
+      `
+        MATCH (from:AilssNote { path: $path })-[edge:AILSS_TYPED_LINK]->(target:AilssTarget)
+        OPTIONAL MATCH (target)-[:AILSS_RESOLVES_TO]->(to:AilssNote)
+        RETURN
+          from.path AS fromPath,
+          to.path AS toPath,
+          edge.rel AS rel,
+          target.target AS target,
+          edge.to_wikilink AS toWikilink,
+          edge.position AS position
+        ORDER BY position, rel, target, toPath
+        LIMIT $limit
+      `,
+      { path, limit: neo4j.int(limit) },
+    ),
+  );
+
+  return result.records.map((row) => ({
+    fromPath: toStringOrEmpty(row.get("fromPath")),
+    toPath: toNullableString(row.get("toPath")),
+    rel: toStringOrEmpty(row.get("rel")),
+    target: toStringOrEmpty(row.get("target")),
+    toWikilink: toStringOrEmpty(row.get("toWikilink")),
+  }));
+}
+
+async function queryIncomingRows(
+  session: Session,
+  path: string,
+  limit: number,
+): Promise<RawTraversalRow[]> {
+  const result = await session.executeRead((tx) =>
+    tx.run(
+      `
+        MATCH (target:AilssTarget)-[:AILSS_RESOLVES_TO]->(to:AilssNote { path: $path })
+        MATCH (from:AilssNote)-[edge:AILSS_TYPED_LINK]->(target)
+        RETURN
+          from.path AS fromPath,
+          to.path AS toPath,
+          edge.rel AS rel,
+          target.target AS target,
+          edge.to_wikilink AS toWikilink,
+          edge.position AS position
+        ORDER BY fromPath, position, rel, target
+        LIMIT $limit
+      `,
+      { path, limit: neo4j.int(limit) },
+    ),
+  );
+
+  return result.records.map((row) => ({
+    fromPath: toStringOrEmpty(row.get("fromPath")),
+    toPath: toNullableString(row.get("toPath")),
+    rel: toStringOrEmpty(row.get("rel")),
+    target: toStringOrEmpty(row.get("target")),
+    toWikilink: toStringOrEmpty(row.get("toWikilink")),
+  }));
+}
+
+export async function traverseNeo4jGraph(
+  config: Neo4jConnectionConfig,
+  options: TraverseNeo4jGraphOptions,
+): Promise<Neo4jTraversalResult> {
+  const seedPath = options.path.trim();
+  if (!seedPath) {
+    throw new Error("Neo4j traversal path is required.");
+  }
+
+  const direction: Neo4jTraversalDirection = options.direction ?? "both";
+  const maxHops = Math.min(Math.max(1, options.maxHops ?? 2), 6);
+  const maxNotes = Math.min(Math.max(1, options.maxNotes ?? 80), 400);
+  const maxEdges = Math.min(Math.max(1, options.maxEdges ?? 1500), 10000);
+  const maxLinksPerNote = Math.min(Math.max(1, options.maxLinksPerNote ?? 80), 500);
+  const includeUnresolvedTargets = options.includeUnresolvedTargets ?? false;
+
+  const driver = createNeo4jDriver(config);
+  try {
+    await driver.verifyConnectivity();
+    const session = driver.session({
+      database: config.database,
+      defaultAccessMode: neo4j.session.READ,
+    });
+    try {
+      const seedCheck = await session.executeRead((tx) =>
+        tx.run(
+          `
+            MATCH (n:AilssNote { path: $path })
+            RETURN n.path AS path
+            LIMIT 1
+          `,
+          { path: seedPath },
+        ),
+      );
+      if (seedCheck.records.length === 0) {
+        throw new Error(
+          `Neo4j seed note not found for path="${seedPath}". Re-run indexer sync to refresh the graph mirror.`,
+        );
+      }
+
+      const nodes: Neo4jTraversalNode[] = [];
+      const edges: Neo4jTraversalEdge[] = [];
+      const edgeSeen = new Set<string>();
+      const visited = new Set<string>([seedPath]);
+      const queue: Array<{ path: string; hop: number }> = [{ path: seedPath, hop: 0 }];
+
+      let truncated = false;
+
+      while (queue.length > 0 && nodes.length < maxNotes) {
+        const current = queue.shift();
+        if (!current) break;
+
+        nodes.push({ path: current.path, hop: current.hop });
+        if (current.hop >= maxHops) continue;
+
+        if (direction === "outgoing" || direction === "both") {
+          const rows = await queryOutgoingRows(session, current.path, maxLinksPerNote);
+          for (const row of rows) {
+            if (!row.fromPath || !row.rel || !row.target) continue;
+            if (row.toPath === null && !includeUnresolvedTargets) continue;
+
+            const edgeKey = [
+              "outgoing",
+              row.fromPath,
+              row.toPath ?? "",
+              row.rel,
+              row.target,
+              row.toWikilink,
+            ].join("::");
+            if (edgeSeen.has(edgeKey)) continue;
+
+            if (edges.length >= maxEdges) {
+              truncated = true;
+              break;
+            }
+
+            edgeSeen.add(edgeKey);
+            edges.push({
+              direction: "outgoing",
+              fromPath: row.fromPath,
+              toPath: row.toPath,
+              rel: row.rel,
+              target: row.target,
+              toWikilink: row.toWikilink,
+            });
+
+            if (!row.toPath || visited.has(row.toPath)) continue;
+            if (nodes.length + queue.length >= maxNotes) {
+              truncated = true;
+              continue;
+            }
+            visited.add(row.toPath);
+            queue.push({ path: row.toPath, hop: current.hop + 1 });
+          }
+        }
+
+        if (truncated) break;
+
+        if (direction === "incoming" || direction === "both") {
+          const rows = await queryIncomingRows(session, current.path, maxLinksPerNote);
+          for (const row of rows) {
+            if (!row.fromPath || !row.rel || !row.target) continue;
+
+            const edgeKey = [
+              "incoming",
+              row.fromPath,
+              row.toPath ?? "",
+              row.rel,
+              row.target,
+              row.toWikilink,
+            ].join("::");
+            if (edgeSeen.has(edgeKey)) continue;
+
+            if (edges.length >= maxEdges) {
+              truncated = true;
+              break;
+            }
+
+            edgeSeen.add(edgeKey);
+            edges.push({
+              direction: "incoming",
+              fromPath: row.fromPath,
+              toPath: row.toPath,
+              rel: row.rel,
+              target: row.target,
+              toWikilink: row.toWikilink,
+            });
+
+            if (visited.has(row.fromPath)) continue;
+            if (nodes.length + queue.length >= maxNotes) {
+              truncated = true;
+              continue;
+            }
+            visited.add(row.fromPath);
+            queue.push({ path: row.fromPath, hop: current.hop + 1 });
+          }
+        }
+
+        if (truncated) break;
+      }
+
+      return { nodes, edges, truncated };
+    } finally {
+      await session.close();
+    }
+  } finally {
+    await driver.close();
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,5 @@ export * from "./vault/frontmatter.js";
 export * from "./db/db.js";
 export * from "./db/types.js";
 export * from "./env.js";
+export * from "./graph/neo4j.js";
 export * from "./indexing/indexVault.js";

--- a/packages/core/test/neo4jSettings.test.ts
+++ b/packages/core/test/neo4jSettings.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveNeo4jSettings } from "../src/index.js";
+
+describe("resolveNeo4jSettings", () => {
+  it("returns disabled settings by default", () => {
+    const settings = resolveNeo4jSettings({
+      neo4jEnabled: false,
+      neo4jUri: undefined,
+      neo4jUsername: undefined,
+      neo4jPassword: undefined,
+      neo4jDatabase: "neo4j",
+      neo4jSyncOnIndex: true,
+      neo4jStrictMode: false,
+    });
+
+    expect(settings.enabled).toBe(false);
+    expect(settings.config).toBeNull();
+    expect(settings.unavailableReason).toMatch(/disabled/i);
+  });
+
+  it("returns unavailable reason when required credentials are missing", () => {
+    const settings = resolveNeo4jSettings({
+      neo4jEnabled: true,
+      neo4jUri: "bolt://127.0.0.1:7687",
+      neo4jUsername: undefined,
+      neo4jPassword: undefined,
+      neo4jDatabase: "neo4j",
+      neo4jSyncOnIndex: true,
+      neo4jStrictMode: true,
+    });
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.config).toBeNull();
+    expect(settings.unavailableReason).toMatch(/configured/i);
+    expect(settings.strictMode).toBe(true);
+  });
+
+  it("returns normalized config when all credentials are present", () => {
+    const settings = resolveNeo4jSettings({
+      neo4jEnabled: true,
+      neo4jUri: " bolt://127.0.0.1:7687 ",
+      neo4jUsername: " neo4j ",
+      neo4jPassword: " password ",
+      neo4jDatabase: " neo4j ",
+      neo4jSyncOnIndex: false,
+      neo4jStrictMode: true,
+    });
+
+    expect(settings.enabled).toBe(true);
+    expect(settings.syncOnIndex).toBe(false);
+    expect(settings.strictMode).toBe(true);
+    expect(settings.unavailableReason).toBeNull();
+    expect(settings.config).toEqual({
+      uri: "bolt://127.0.0.1:7687",
+      username: "neo4j",
+      password: "password",
+      database: "neo4j",
+    });
+  });
+});

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
 
-import { loadEnv, openAilssDb, resolveDefaultDbPath } from "@ailss/core";
+import { loadEnv, openAilssDb, resolveDefaultDbPath, resolveNeo4jSettings } from "@ailss/core";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { AsyncMutex } from "./lib/asyncMutex.js";
@@ -18,6 +18,8 @@ import { registerGetVaultTreeTool } from "./tools/getVaultTree.js";
 import { registerImproveFrontmatterTool } from "./tools/improveFrontmatter.js";
 import { registerListKeywordsTool } from "./tools/listKeywords.js";
 import { registerListTagsTool } from "./tools/listTags.js";
+import { registerNeo4jGraphStatusTool } from "./tools/neo4jGraphStatus.js";
+import { registerNeo4jGraphTraverseTool } from "./tools/neo4jGraphTraverse.js";
 import { registerRelocateNoteTool } from "./tools/relocateNote.js";
 import { registerResolveNoteTool } from "./tools/resolveNote.js";
 import { registerSearchNotesTool } from "./tools/searchNotes.js";
@@ -46,6 +48,7 @@ export async function createAilssMcpRuntimeFromEnv(): Promise<AilssMcpRuntime> {
 
   const db = openAilssDb({ dbPath, embeddingModel, embeddingDim });
   const openai = new OpenAI({ apiKey: openaiApiKey });
+  const neo4j = resolveNeo4jSettings(env);
 
   return {
     deps: {
@@ -54,6 +57,7 @@ export async function createAilssMcpRuntimeFromEnv(): Promise<AilssMcpRuntime> {
       vaultPath,
       openai,
       embeddingModel,
+      neo4j,
       writeLock: new AsyncMutex(),
     },
     enableWriteTools: env.enableWriteTools,
@@ -79,6 +83,8 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   registerListTagsTool(server, deps);
   registerListKeywordsTool(server, deps);
   registerFindTypedLinksIncomingTool(server, deps);
+  registerNeo4jGraphStatusTool(server, deps);
+  registerNeo4jGraphTraverseTool(server, deps);
 
   if (runtime.enableWriteTools) {
     registerCaptureNoteTool(server, deps);

--- a/packages/mcp/src/mcpDeps.ts
+++ b/packages/mcp/src/mcpDeps.ts
@@ -1,6 +1,7 @@
 // Shared dependency container for MCP tool registration
 
 import type { AilssDb } from "@ailss/core";
+import type { Neo4jSettings } from "@ailss/core";
 import type OpenAI from "openai";
 
 export type WriteLock = {
@@ -13,5 +14,6 @@ export type McpToolDeps = {
   vaultPath: string | undefined;
   openai: OpenAI;
   embeddingModel: string;
+  neo4j?: Neo4jSettings;
   writeLock?: WriteLock;
 };

--- a/packages/mcp/src/tools/neo4jGraphStatus.ts
+++ b/packages/mcp/src/tools/neo4jGraphStatus.ts
@@ -22,6 +22,11 @@ export function registerNeo4jGraphStatusTool(server: McpServer, deps: McpToolDep
         sync_on_index: z.boolean(),
         strict_mode: z.boolean(),
         reason: z.string().nullable(),
+        active_run_id: z.string().nullable(),
+        mirror_status: z.enum(["empty", "ok", "error"]),
+        last_success_at: z.string().nullable(),
+        last_error: z.string().nullable(),
+        last_error_at: z.string().nullable(),
         sqlite_counts: z.object({
           notes: z.number().int().nonnegative(),
           typed_links: z.number().int().nonnegative(),
@@ -54,6 +59,11 @@ export function registerNeo4jGraphStatusTool(server: McpServer, deps: McpToolDep
         sync_on_index: neo4j.syncOnIndex,
         strict_mode: neo4j.strictMode,
         reason: neo4j.unavailableReason,
+        active_run_id: null as string | null,
+        mirror_status: "empty" as "empty" | "ok" | "error",
+        last_success_at: null as string | null,
+        last_error: null as string | null,
+        last_error_at: null as string | null,
         sqlite_counts: {
           notes: sqliteCounts.notes,
           typed_links: sqliteCounts.typedLinks,
@@ -80,6 +90,11 @@ export function registerNeo4jGraphStatusTool(server: McpServer, deps: McpToolDep
           ...basePayload,
           available: true,
           reason: null,
+          active_run_id: status.activeRunId,
+          mirror_status: status.mirrorStatus,
+          last_success_at: status.lastSuccessAt,
+          last_error: status.lastError,
+          last_error_at: status.lastErrorAt,
           neo4j_counts: {
             notes: status.neo4jCounts.notes,
             typed_links: status.neo4jCounts.typedLinks,
@@ -97,6 +112,8 @@ export function registerNeo4jGraphStatusTool(server: McpServer, deps: McpToolDep
         const payload = {
           ...basePayload,
           reason: `Neo4j unavailable: ${message}`,
+          mirror_status: "error" as "empty" | "ok" | "error",
+          last_error: message,
         };
         return {
           structuredContent: payload,

--- a/packages/mcp/src/tools/neo4jGraphStatus.ts
+++ b/packages/mcp/src/tools/neo4jGraphStatus.ts
@@ -1,0 +1,108 @@
+// neo4j_graph_status tool
+// - optional Neo4j availability and consistency checks
+
+import { getSqliteGraphCounts, readNeo4jGraphStatus } from "@ailss/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+
+export function registerNeo4jGraphStatusTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "neo4j_graph_status",
+    {
+      title: "Neo4j graph status",
+      description:
+        "Returns optional Neo4j graph mirror status and SQLite↔Neo4j consistency checks. When Neo4j is disabled/unavailable, reports a non-fatal fallback status.",
+      inputSchema: {},
+      outputSchema: z.object({
+        enabled: z.boolean(),
+        configured: z.boolean(),
+        available: z.boolean(),
+        sync_on_index: z.boolean(),
+        strict_mode: z.boolean(),
+        reason: z.string().nullable(),
+        sqlite_counts: z.object({
+          notes: z.number().int().nonnegative(),
+          typed_links: z.number().int().nonnegative(),
+        }),
+        neo4j_counts: z
+          .object({
+            notes: z.number().int().nonnegative(),
+            typed_links: z.number().int().nonnegative(),
+            targets: z.number().int().nonnegative(),
+            resolved_links: z.number().int().nonnegative(),
+          })
+          .nullable(),
+        consistent: z.boolean().nullable(),
+      }),
+    },
+    async () => {
+      const neo4j = deps.neo4j ?? {
+        enabled: false,
+        syncOnIndex: false,
+        strictMode: false,
+        config: null,
+        unavailableReason: "Neo4j integration is not configured in this MCP runtime.",
+      };
+      const sqliteCounts = getSqliteGraphCounts(deps.db);
+
+      const basePayload = {
+        enabled: neo4j.enabled,
+        configured: Boolean(neo4j.config),
+        available: false,
+        sync_on_index: neo4j.syncOnIndex,
+        strict_mode: neo4j.strictMode,
+        reason: neo4j.unavailableReason,
+        sqlite_counts: {
+          notes: sqliteCounts.notes,
+          typed_links: sqliteCounts.typedLinks,
+        },
+        neo4j_counts: null as {
+          notes: number;
+          typed_links: number;
+          targets: number;
+          resolved_links: number;
+        } | null,
+        consistent: null as boolean | null,
+      };
+
+      if (!neo4j.enabled || !neo4j.config) {
+        return {
+          structuredContent: basePayload,
+          content: [{ type: "text", text: JSON.stringify(basePayload, null, 2) }],
+        };
+      }
+
+      try {
+        const status = await readNeo4jGraphStatus(deps.db, neo4j.config);
+        const payload = {
+          ...basePayload,
+          available: true,
+          reason: null,
+          neo4j_counts: {
+            notes: status.neo4jCounts.notes,
+            typed_links: status.neo4jCounts.typedLinks,
+            targets: status.neo4jCounts.targets,
+            resolved_links: status.neo4jCounts.resolvedLinks,
+          },
+          consistent: status.consistent,
+        };
+        return {
+          structuredContent: payload,
+          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const payload = {
+          ...basePayload,
+          reason: `Neo4j unavailable: ${message}`,
+        };
+        return {
+          structuredContent: payload,
+          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/neo4jGraphTraverse.ts
+++ b/packages/mcp/src/tools/neo4jGraphTraverse.ts
@@ -1,0 +1,352 @@
+// neo4j_graph_traverse tool
+// - optional multi-hop traversal over Neo4j graph mirror
+
+import {
+  getNoteMeta,
+  resolveNotePathsByWikilinkTarget,
+  traverseNeo4jGraph,
+  type Neo4jTraversalDirection,
+} from "@ailss/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+
+type TraversalNodePayload = {
+  path: string;
+  hop: number;
+  title: string | null;
+  summary: string | null;
+  entity: string | null;
+  layer: string | null;
+  status: string | null;
+  updated: string | null;
+  tags: string[];
+  keywords: string[];
+};
+
+type TraversalEdgePayload = {
+  direction: "outgoing" | "incoming";
+  from_path: string;
+  to_path: string | null;
+  rel: string;
+  target: string;
+  to_wikilink: string;
+};
+
+type SqliteFallbackTraversal = {
+  nodes: TraversalNodePayload[];
+  edges: TraversalEdgePayload[];
+  truncated: boolean;
+};
+
+function toNodePayload(deps: McpToolDeps, notePath: string, hop: number): TraversalNodePayload {
+  const meta = getNoteMeta(deps.db, notePath);
+  return {
+    path: notePath,
+    hop,
+    title: meta?.title ?? null,
+    summary: meta?.summary ?? null,
+    entity: meta?.entity ?? null,
+    layer: meta?.layer ?? null,
+    status: meta?.status ?? null,
+    updated: meta?.updated ?? null,
+    tags: meta?.tags ?? [],
+    keywords: meta?.keywords ?? [],
+  };
+}
+
+function runSqliteFallbackTraversal(
+  deps: McpToolDeps,
+  args: {
+    path: string;
+    max_hops: number;
+    max_notes: number;
+    max_edges: number;
+    max_links_per_note: number;
+    include_unresolved_targets: boolean;
+  },
+): SqliteFallbackTraversal {
+  const seedMeta = getNoteMeta(deps.db, args.path);
+  if (!seedMeta) {
+    throw new Error(
+      `Note metadata not found for path="${args.path}". Re-run indexing so typed links are available.`,
+    );
+  }
+
+  const nodes: TraversalNodePayload[] = [];
+  const edges: TraversalEdgePayload[] = [];
+  const edgeSeen = new Set<string>();
+  const visited = new Set<string>([args.path]);
+  const queue: Array<{ path: string; hop: number }> = [{ path: args.path, hop: 0 }];
+
+  let truncated = false;
+
+  while (queue.length > 0 && nodes.length < args.max_notes) {
+    const current = queue.shift();
+    if (!current) break;
+
+    nodes.push(toNodePayload(deps, current.path, current.hop));
+    if (current.hop >= args.max_hops) continue;
+
+    const meta = getNoteMeta(deps.db, current.path);
+    if (!meta) continue;
+
+    for (const link of meta.typedLinks.slice(0, args.max_links_per_note)) {
+      const resolved = resolveNotePathsByWikilinkTarget(deps.db, link.toTarget, 20);
+
+      if (resolved.length === 0 && args.include_unresolved_targets) {
+        const unresolvedKey = [
+          "outgoing",
+          current.path,
+          "",
+          link.rel,
+          link.toTarget,
+          link.toWikilink,
+        ].join("::");
+        if (!edgeSeen.has(unresolvedKey)) {
+          if (edges.length >= args.max_edges) {
+            truncated = true;
+            break;
+          }
+          edgeSeen.add(unresolvedKey);
+          edges.push({
+            direction: "outgoing",
+            from_path: current.path,
+            to_path: null,
+            rel: link.rel,
+            target: link.toTarget,
+            to_wikilink: link.toWikilink,
+          });
+        }
+      }
+
+      for (const match of resolved) {
+        const edgeKey = [
+          "outgoing",
+          current.path,
+          match.path,
+          link.rel,
+          link.toTarget,
+          link.toWikilink,
+        ].join("::");
+        if (edgeSeen.has(edgeKey)) continue;
+
+        if (edges.length >= args.max_edges) {
+          truncated = true;
+          break;
+        }
+
+        edgeSeen.add(edgeKey);
+        edges.push({
+          direction: "outgoing",
+          from_path: current.path,
+          to_path: match.path,
+          rel: link.rel,
+          target: link.toTarget,
+          to_wikilink: link.toWikilink,
+        });
+
+        if (visited.has(match.path)) continue;
+        if (nodes.length + queue.length >= args.max_notes) {
+          truncated = true;
+          continue;
+        }
+        visited.add(match.path);
+        queue.push({ path: match.path, hop: current.hop + 1 });
+      }
+
+      if (truncated) break;
+    }
+
+    if (truncated) break;
+  }
+
+  return { nodes, edges, truncated };
+}
+
+export function registerNeo4jGraphTraverseTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "neo4j_graph_traverse",
+    {
+      title: "Neo4j graph traverse",
+      description:
+        "Traverses the optional Neo4j graph mirror for multi-hop typed-link exploration. Falls back to SQLite outgoing traversal when Neo4j is unavailable.",
+      inputSchema: {
+        path: z.string().min(1).describe("Vault-relative seed note path"),
+        direction: z
+          .enum(["outgoing", "incoming", "both"])
+          .default("both")
+          .describe("Traversal direction over resolved typed-link graph"),
+        max_hops: z.number().int().min(1).max(6).default(2).describe("Maximum traversal depth"),
+        max_notes: z
+          .number()
+          .int()
+          .min(1)
+          .max(400)
+          .default(80)
+          .describe("Maximum number of note nodes returned"),
+        max_edges: z
+          .number()
+          .int()
+          .min(1)
+          .max(10_000)
+          .default(1500)
+          .describe("Maximum number of edges returned"),
+        max_links_per_note: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .default(80)
+          .describe("Maximum graph edges queried per expanded note"),
+        include_unresolved_targets: z
+          .boolean()
+          .default(false)
+          .describe("Include unresolved targets as edges with to_path=null"),
+      },
+      outputSchema: z.object({
+        backend: z.enum(["neo4j", "sqlite_fallback"]),
+        reason: z.string().nullable(),
+        seed_path: z.string(),
+        params: z.object({
+          direction: z.enum(["outgoing", "incoming", "both"]),
+          max_hops: z.number().int(),
+          max_notes: z.number().int(),
+          max_edges: z.number().int(),
+          max_links_per_note: z.number().int(),
+          include_unresolved_targets: z.boolean(),
+        }),
+        truncated: z.boolean(),
+        nodes: z.array(
+          z.object({
+            path: z.string(),
+            hop: z.number().int().nonnegative(),
+            title: z.string().nullable(),
+            summary: z.string().nullable(),
+            entity: z.string().nullable(),
+            layer: z.string().nullable(),
+            status: z.string().nullable(),
+            updated: z.string().nullable(),
+            tags: z.array(z.string()),
+            keywords: z.array(z.string()),
+          }),
+        ),
+        edges: z.array(
+          z.object({
+            direction: z.enum(["outgoing", "incoming"]),
+            from_path: z.string(),
+            to_path: z.string().nullable(),
+            rel: z.string(),
+            target: z.string(),
+            to_wikilink: z.string(),
+          }),
+        ),
+      }),
+    },
+    async (args) => {
+      const neo4j = deps.neo4j ?? {
+        enabled: false,
+        syncOnIndex: false,
+        strictMode: false,
+        config: null,
+        unavailableReason: "Neo4j integration is not configured in this MCP runtime.",
+      };
+      const direction = args.direction as Neo4jTraversalDirection;
+      const baseParams = {
+        direction,
+        max_hops: args.max_hops,
+        max_notes: args.max_notes,
+        max_edges: args.max_edges,
+        max_links_per_note: args.max_links_per_note,
+        include_unresolved_targets: args.include_unresolved_targets,
+      };
+
+      if (!neo4j.enabled || !neo4j.config) {
+        const fallback = runSqliteFallbackTraversal(deps, {
+          path: args.path,
+          max_hops: args.max_hops,
+          max_notes: args.max_notes,
+          max_edges: args.max_edges,
+          max_links_per_note: args.max_links_per_note,
+          include_unresolved_targets: args.include_unresolved_targets,
+        });
+        const payload = {
+          backend: "sqlite_fallback" as const,
+          reason:
+            direction === "outgoing"
+              ? (neo4j.unavailableReason ?? "Neo4j unavailable.")
+              : `Neo4j unavailable. Fallback only supports outgoing traversal. Requested direction=${direction}.`,
+          seed_path: args.path,
+          params: baseParams,
+          truncated: fallback.truncated,
+          nodes: fallback.nodes,
+          edges: fallback.edges,
+        };
+        return {
+          structuredContent: payload,
+          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        };
+      }
+
+      try {
+        const traversal = await traverseNeo4jGraph(neo4j.config, {
+          path: args.path,
+          direction,
+          maxHops: args.max_hops,
+          maxNotes: args.max_notes,
+          maxEdges: args.max_edges,
+          maxLinksPerNote: args.max_links_per_note,
+          includeUnresolvedTargets: args.include_unresolved_targets,
+        });
+
+        const nodes = traversal.nodes.map((node) => toNodePayload(deps, node.path, node.hop));
+        const edges = traversal.edges.map((edge) => ({
+          direction: edge.direction,
+          from_path: edge.fromPath,
+          to_path: edge.toPath,
+          rel: edge.rel,
+          target: edge.target,
+          to_wikilink: edge.toWikilink,
+        }));
+
+        const payload = {
+          backend: "neo4j" as const,
+          reason: null,
+          seed_path: args.path,
+          params: baseParams,
+          truncated: traversal.truncated,
+          nodes,
+          edges,
+        };
+        return {
+          structuredContent: payload,
+          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        };
+      } catch (error) {
+        const fallback = runSqliteFallbackTraversal(deps, {
+          path: args.path,
+          max_hops: args.max_hops,
+          max_notes: args.max_notes,
+          max_edges: args.max_edges,
+          max_links_per_note: args.max_links_per_note,
+          include_unresolved_targets: args.include_unresolved_targets,
+        });
+        const message = error instanceof Error ? error.message : String(error);
+        const payload = {
+          backend: "sqlite_fallback" as const,
+          reason: `Neo4j traversal failed; fallback used: ${message}`,
+          seed_path: args.path,
+          params: baseParams,
+          truncated: fallback.truncated,
+          nodes: fallback.nodes,
+          edges: fallback.edges,
+        };
+        return {
+          structuredContent: payload,
+          content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -16,7 +16,14 @@ type EnvKey =
   | "OPENAI_EMBEDDING_MODEL"
   | "AILSS_DB_PATH"
   | "AILSS_VAULT_PATH"
-  | "AILSS_ENABLE_WRITE_TOOLS";
+  | "AILSS_ENABLE_WRITE_TOOLS"
+  | "AILSS_NEO4J_ENABLED"
+  | "AILSS_NEO4J_URI"
+  | "AILSS_NEO4J_USERNAME"
+  | "AILSS_NEO4J_PASSWORD"
+  | "AILSS_NEO4J_DATABASE"
+  | "AILSS_NEO4J_SYNC_ON_INDEX"
+  | "AILSS_NEO4J_STRICT_MODE";
 
 export type EnvOverrides = Partial<Record<EnvKey, string | undefined>>;
 
@@ -84,6 +91,13 @@ function envForMcpRuntime(
     AILSS_DB_PATH: "",
     AILSS_VAULT_PATH: "",
     AILSS_ENABLE_WRITE_TOOLS: "",
+    AILSS_NEO4J_ENABLED: "",
+    AILSS_NEO4J_URI: "",
+    AILSS_NEO4J_USERNAME: "",
+    AILSS_NEO4J_PASSWORD: "",
+    AILSS_NEO4J_DATABASE: "",
+    AILSS_NEO4J_SYNC_ON_INDEX: "",
+    AILSS_NEO4J_STRICT_MODE: "",
   };
 
   if (options.dbPath) {

--- a/packages/mcp/test/httpTools.neo4jGraphStatus.test.ts
+++ b/packages/mcp/test/httpTools.neo4jGraphStatus.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import path from "node:path";
+
+import {
+  assertRecord,
+  getStructuredContent,
+  mcpInitialize,
+  mcpToolsCall,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+describe("MCP HTTP server (neo4j_graph_status)", () => {
+  it("returns fallback status and SQLite graph counts when Neo4j is disabled", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer(
+        { dbPath, enableWriteTools: false },
+        async ({ url, token, runtime }) => {
+          const now = new Date().toISOString().slice(0, 19);
+
+          runtime.deps.db
+            .prepare(
+              "INSERT INTO files(path, mtime_ms, size_bytes, sha256, updated_at) VALUES (?, ?, ?, ?, ?)",
+            )
+            .run("A.md", 0, 0, "0", now);
+
+          runtime.deps.db
+            .prepare(
+              "INSERT INTO notes(path, note_id, created, title, summary, entity, layer, status, updated, frontmatter_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            )
+            .run(
+              "A.md",
+              "20260101000000",
+              "2026-01-01T00:00:00",
+              "A",
+              null,
+              null,
+              null,
+              null,
+              now,
+              JSON.stringify({ id: "20260101000000", title: "A" }),
+              now,
+            );
+
+          runtime.deps.db
+            .prepare(
+              "INSERT INTO typed_links(from_path, rel, to_target, to_wikilink, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .run("A.md", "depends_on", "B", "[[B]]", 0, now);
+
+          const sessionId = await mcpInitialize(url, token, "client-status");
+          const response = await mcpToolsCall(url, token, sessionId, "neo4j_graph_status", {});
+          const structured = getStructuredContent(response);
+
+          expect(structured["enabled"]).toBe(false);
+          expect(structured["configured"]).toBe(false);
+          expect(structured["available"]).toBe(false);
+          expect(structured["neo4j_counts"]).toBeNull();
+          expect(structured["consistent"]).toBeNull();
+
+          const sqliteCounts = structured["sqlite_counts"];
+          assertRecord(sqliteCounts, "sqlite_counts");
+          expect(sqliteCounts["notes"]).toBe(1);
+          expect(sqliteCounts["typed_links"]).toBe(1);
+        },
+      );
+    });
+  });
+});

--- a/packages/mcp/test/httpTools.neo4jGraphStatus.test.ts
+++ b/packages/mcp/test/httpTools.neo4jGraphStatus.test.ts
@@ -60,6 +60,9 @@ describe("MCP HTTP server (neo4j_graph_status)", () => {
           expect(structured["available"]).toBe(false);
           expect(structured["neo4j_counts"]).toBeNull();
           expect(structured["consistent"]).toBeNull();
+          expect(structured["active_run_id"]).toBeNull();
+          expect(structured["mirror_status"]).toBe("empty");
+          expect(structured["last_success_at"]).toBeNull();
 
           const sqliteCounts = structured["sqlite_counts"];
           assertRecord(sqliteCounts, "sqlite_counts");

--- a/packages/mcp/test/httpTools.neo4jGraphTraverse.test.ts
+++ b/packages/mcp/test/httpTools.neo4jGraphTraverse.test.ts
@@ -77,6 +77,7 @@ describe("MCP HTTP server (neo4j_graph_traverse)", () => {
 
           expect(structured["backend"]).toBe("sqlite_fallback");
           expect(structured["seed_path"]).toBe("A.md");
+          expect(structured["active_run_id"]).toBeNull();
           expect(structured["truncated"]).toBe(false);
 
           const nodes = structured["nodes"];

--- a/packages/mcp/test/httpTools.neo4jGraphTraverse.test.ts
+++ b/packages/mcp/test/httpTools.neo4jGraphTraverse.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import path from "node:path";
+
+import {
+  assertArray,
+  getStructuredContent,
+  mcpInitialize,
+  mcpToolsCall,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+describe("MCP HTTP server (neo4j_graph_traverse)", () => {
+  it("falls back to SQLite traversal when Neo4j is disabled", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer(
+        { dbPath, enableWriteTools: false },
+        async ({ url, token, runtime }) => {
+          const now = new Date().toISOString().slice(0, 19);
+
+          const fileStmt = runtime.deps.db.prepare(
+            "INSERT INTO files(path, mtime_ms, size_bytes, sha256, updated_at) VALUES (?, ?, ?, ?, ?)",
+          );
+          const noteStmt = runtime.deps.db.prepare(
+            "INSERT INTO notes(path, note_id, created, title, summary, entity, layer, status, updated, frontmatter_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          );
+          const typedLinkStmt = runtime.deps.db.prepare(
+            "INSERT INTO typed_links(from_path, rel, to_target, to_wikilink, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+          );
+
+          fileStmt.run("A.md", 0, 0, "a", now);
+          fileStmt.run("B.md", 0, 0, "b", now);
+
+          noteStmt.run(
+            "A.md",
+            "20260101000000",
+            "2026-01-01T00:00:00",
+            "A",
+            null,
+            null,
+            null,
+            null,
+            now,
+            JSON.stringify({ id: "20260101000000", title: "A" }),
+            now,
+          );
+          noteStmt.run(
+            "B.md",
+            "20260102000000",
+            "2026-01-02T00:00:00",
+            "B",
+            null,
+            null,
+            null,
+            null,
+            now,
+            JSON.stringify({ id: "20260102000000", title: "B" }),
+            now,
+          );
+
+          typedLinkStmt.run("A.md", "depends_on", "B", "[[B]]", 0, now);
+
+          const sessionId = await mcpInitialize(url, token, "client-traverse");
+          const response = await mcpToolsCall(url, token, sessionId, "neo4j_graph_traverse", {
+            path: "A.md",
+            direction: "outgoing",
+            max_hops: 2,
+            max_notes: 50,
+            max_edges: 200,
+            max_links_per_note: 20,
+            include_unresolved_targets: false,
+          });
+          const structured = getStructuredContent(response);
+
+          expect(structured["backend"]).toBe("sqlite_fallback");
+          expect(structured["seed_path"]).toBe("A.md");
+          expect(structured["truncated"]).toBe(false);
+
+          const nodes = structured["nodes"];
+          assertArray(nodes, "nodes");
+          const nodePaths = nodes
+            .map((node) => (node as Record<string, unknown>)["path"])
+            .filter((value): value is string => typeof value === "string")
+            .sort((a, b) => a.localeCompare(b));
+          expect(nodePaths).toEqual(["A.md", "B.md"]);
+
+          const edges = structured["edges"];
+          assertArray(edges, "edges");
+          expect(edges).toHaveLength(1);
+          const first = edges[0] as Record<string, unknown>;
+          expect(first["direction"]).toBe("outgoing");
+          expect(first["from_path"]).toBe("A.md");
+          expect(first["to_path"]).toBe("B.md");
+          expect(first["rel"]).toBe("depends_on");
+        },
+      );
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      neo4j-driver:
+        specifier: ^5.28.2
+        version: 5.28.3
       sqlite-vec:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
@@ -932,6 +935,9 @@ packages:
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2015,6 +2021,15 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  neo4j-driver-bolt-connection@5.28.3:
+    resolution: {integrity: sha512-wqHBYcU0FVRDmdsoZ+Fk0S/InYmu9/4BT6fPYh45Jimg/J7vQBUcdkiHGU7nop7HRb1ZgJmL305mJb6g5Bv35Q==}
+
+  neo4j-driver-core@5.28.3:
+    resolution: {integrity: sha512-Jk+hAmjFmO5YzVH/U7FyKXigot9zmIfLz6SZQy0xfr4zfTE/S8fOYFOGqKQTHBE86HHOWH2RbTslbxIb+XtU2g==}
+
+  neo4j-driver@5.28.3:
+    resolution: {integrity: sha512-k7c0wEh3HoONv1v5AyLp9/BDAbYHJhz2TZvzWstSEU3g3suQcXmKEaYBfrK2UMzxcy3bCT0DrnfRbzsOW5G/Ag==}
+
   node-abi@3.85.0:
     resolution: {integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==}
     engines: {node: '>=10'}
@@ -2272,6 +2287,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-array-concat@1.1.3:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
@@ -3641,6 +3659,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -4847,6 +4870,20 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  neo4j-driver-bolt-connection@5.28.3:
+    dependencies:
+      buffer: 6.0.3
+      neo4j-driver-core: 5.28.3
+      string_decoder: 1.3.0
+
+  neo4j-driver-core@5.28.3: {}
+
+  neo4j-driver@5.28.3:
+    dependencies:
+      neo4j-driver-bolt-connection: 5.28.3
+      neo4j-driver-core: 5.28.3
+      rxjs: 7.8.2
+
   node-abi@3.85.0:
     dependencies:
       semver: 7.7.3
@@ -5142,6 +5179,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.4.0
 
   safe-array-concat@1.1.3:
     dependencies:


### PR DESCRIPTION
## What

- Add optional Neo4j hybrid integration in `@ailss/core` with env-driven settings, SQLite graph mirror sync, consistency status, and traversal helpers.
- Run optional post-index Neo4j sync in `@ailss/indexer` with strict/best-effort fallback behavior.
- Add MCP read tools `neo4j_graph_status` and `neo4j_graph_traverse` with explicit SQLite fallback when Neo4j is disabled or unavailable.
- Add tests for Neo4j settings/MCP fallback behavior and update docs/env examples.

## Why

- Enable graph-native analysis workflows without replacing SQLite as the source of truth.
- Preserve backward compatibility for desktop-first/local-first defaults when Neo4j is not configured.
- Fixes #67

## How

- Introduce `AILSS_NEO4J_*` configuration flags and a Neo4j mirror model (`AilssNote`, `AilssTarget`, `AILSS_TYPED_LINK`, `AILSS_RESOLVES_TO`).
- Mirror SQLite `notes` and `typed_links` to Neo4j in deterministic batches and validate note/link count consistency.
- Register Neo4j read tools in MCP and return structured fallback payloads when Neo4j connectivity/configuration is unavailable.
- Run validation commands: `pnpm build` and `pnpm check`.
