### PR TITLE
feat: add scoped filtering to get_context retrieval

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -33,6 +33,8 @@ Read-first tools (implemented in this repo):
   - Default `top_k` can be set via `AILSS_GET_CONTEXT_DEFAULT_TOP_K` (applies only when the caller omits `top_k`; clamped to 1–50; default: 10)
   - Returns note metadata + stitched evidence chunks by default (file-start previews are disabled unless explicitly enabled)
   - Default `max_chars_per_note` is 800 (applies only when the caller omits it; clamped to 200–50,000; used for file-start previews when enabled)
+  - Optional scoped candidate filters are available: `path_prefix` (literal path prefix), `tags_any`, `tags_all`
+  - Retrieval metadata includes `applied_filters` so callers can verify which scope filters were applied
 - `expand_typed_links_outgoing`: expand outgoing typed links from a specified note path into a bounded graph (DB-backed; metadata only)
 - `find_typed_links_incoming`: find notes that reference a target via typed links (incoming edges)
 - `resolve_note`: resolve an id/title/wikilink target to candidate note paths (DB-backed; intended before `read_note`/`edit_note`)

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -11,6 +11,9 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 - Purpose: semantic retrieval over the index DB (returns note metadata + stitched evidence chunks; optional file-start previews).
 - Input:
   - `query` (string, required)
+  - `path_prefix` (string, optional) — literal vault-relative prefix match for candidate notes (not SQL wildcard semantics)
+  - `tags_any` (string[], default: `[]`) — candidate notes must include at least one tag
+  - `tags_all` (string[], default: `[]`) — candidate notes must include all tags
   - `top_k` (int, default: `10`, range: `1–50`)
   - `expand_top_k` (int, default: `5`, range: `0–50`) — how many of the top_k notes include stitched evidence text
   - `hit_chunks_per_note` (int, default: `2`, range: `1–5`)
@@ -18,6 +21,10 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `max_evidence_chars_per_note` (int, default: `1500`, range: `200–20,000`)
   - `include_file_preview` (boolean, default: `false`) — when true, includes file-start preview (requires `AILSS_VAULT_PATH`)
   - `max_chars_per_note` (int, default: `800`, range: `200–50,000`) — file-start preview size when `include_file_preview=true`
+- Output (selected):
+  - `applied_filters.path_prefix` (`string | null`) — normalized path prefix applied to candidate filtering
+  - `applied_filters.tags_any` (`string[]`) — normalized ANY-tag filter applied to candidate filtering
+  - `applied_filters.tags_all` (`string[]`) — normalized ALL-tag filter applied to candidate filtering
 
 ### `expand_typed_links_outgoing`
 

--- a/packages/core/test/db.test.ts
+++ b/packages/core/test/db.test.ts
@@ -12,6 +12,7 @@ import {
   insertChunkWithEmbedding,
   listFilePaths,
   openAilssDb,
+  replaceNoteTags,
   searchNotes,
   semanticSearch,
   upsertFile,
@@ -62,6 +63,121 @@ describe("openAilssDb() + semanticSearch()", () => {
       expect(results[0]?.chunkId).toBe("chunk-1");
       expect(results[0]?.path).toBe("notes/a.md");
       expect(results[0]?.headingPath).toEqual(["A"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("applies optional path/tag filters to candidate chunks before ranking", async () => {
+    const dir = await mkTempDir();
+    const dbPath = path.join(dir, "index.sqlite");
+    const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+    try {
+      upsertFile(db, {
+        path: "projects/a.md",
+        mtimeMs: 0,
+        sizeBytes: 0,
+        sha256: "file-a",
+      });
+      upsertFile(db, {
+        path: "projects/c.md",
+        mtimeMs: 0,
+        sizeBytes: 0,
+        sha256: "file-c",
+      });
+      upsertFile(db, {
+        path: "personal/b.md",
+        mtimeMs: 0,
+        sizeBytes: 0,
+        sha256: "file-b",
+      });
+
+      upsertNote(db, {
+        path: "projects/a.md",
+        noteId: "a",
+        created: null,
+        title: "A",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+      upsertNote(db, {
+        path: "projects/c.md",
+        noteId: "c",
+        created: null,
+        title: "C",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+      upsertNote(db, {
+        path: "personal/b.md",
+        noteId: "b",
+        created: null,
+        title: "B",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+
+      replaceNoteTags(db, "projects/a.md", ["project"]);
+      replaceNoteTags(db, "projects/c.md", ["project", "urgent"]);
+      replaceNoteTags(db, "personal/b.md", ["personal"]);
+
+      insertChunkWithEmbedding(db, {
+        chunkId: "chunk-a",
+        path: "projects/a.md",
+        chunkIndex: 0,
+        heading: "A",
+        headingPathJson: JSON.stringify(["A"]),
+        content: "project-a",
+        contentSha256: "content-a",
+        embedding: [0.3, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "chunk-c",
+        path: "projects/c.md",
+        chunkIndex: 0,
+        heading: "C",
+        headingPathJson: JSON.stringify(["C"]),
+        content: "project-c",
+        contentSha256: "content-c",
+        embedding: [0.1, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "chunk-b",
+        path: "personal/b.md",
+        chunkIndex: 0,
+        heading: "B",
+        headingPathJson: JSON.stringify(["B"]),
+        content: "personal-b",
+        contentSha256: "content-b",
+        embedding: [0, 0, 0],
+      });
+
+      const unscoped = semanticSearch(db, [0, 0, 0], 3);
+      expect(unscoped.map((r) => r.chunkId)).toEqual(["chunk-b", "chunk-c", "chunk-a"]);
+
+      const pathScoped = semanticSearch(db, [0, 0, 0], 3, { pathPrefix: "projects/" });
+      expect(pathScoped.map((r) => r.chunkId)).toEqual(["chunk-c", "chunk-a"]);
+
+      const tagsAnyScoped = semanticSearch(db, [0, 0, 0], 3, { tagsAny: ["project"] });
+      expect(tagsAnyScoped.map((r) => r.chunkId)).toEqual(["chunk-c", "chunk-a"]);
+
+      const tagsAllScoped = semanticSearch(db, [0, 0, 0], 3, {
+        tagsAll: ["project", "urgent"],
+      });
+      expect(tagsAllScoped.map((r) => r.chunkId)).toEqual(["chunk-c"]);
     } finally {
       db.close();
     }

--- a/packages/mcp/test/httpTools.getContext.test.ts
+++ b/packages/mcp/test/httpTools.getContext.test.ts
@@ -7,7 +7,13 @@ import type { AilssMcpRuntime } from "../src/createAilssMcpServer.js";
 import { AsyncMutex } from "../src/lib/asyncMutex.js";
 import { startAilssMcpHttpServer } from "../src/httpServer.js";
 
-import { insertChunkWithEmbedding, openAilssDb, upsertFile } from "@ailss/core";
+import {
+  insertChunkWithEmbedding,
+  openAilssDb,
+  replaceNoteTags,
+  upsertFile,
+  upsertNote,
+} from "@ailss/core";
 
 import {
   getStructuredContent,
@@ -280,6 +286,142 @@ describe("MCP HTTP server (get_context)", () => {
           .map((c) => c["chunk_index"])
           .sort((a, b) => Number(a) - Number(b));
         expect(indices).toEqual([0, 1, 2, 5]);
+      } finally {
+        await close();
+        db.close();
+      }
+    });
+  });
+
+  it("applies scoped filters before ranking and returns applied_filters metadata", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+      const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+      const queryEmbedding = [0, 0, 0];
+      const openaiStub = {
+        embeddings: {
+          create: async () => ({ data: [{ embedding: queryEmbedding }] }),
+        },
+      } as unknown as AilssMcpRuntime["deps"]["openai"];
+
+      const runtime: AilssMcpRuntime = {
+        deps: {
+          db,
+          dbPath,
+          vaultPath: undefined,
+          openai: openaiStub,
+          embeddingModel: "test-embeddings",
+          writeLock: new AsyncMutex(),
+        },
+        enableWriteTools: false,
+      };
+
+      upsertFile(db, { path: "Projects/Alpha.md", mtimeMs: 0, sizeBytes: 0, sha256: "a" });
+      upsertFile(db, { path: "Projects/Beta.md", mtimeMs: 0, sizeBytes: 0, sha256: "b" });
+      upsertFile(db, { path: "Personal/Gamma.md", mtimeMs: 0, sizeBytes: 0, sha256: "c" });
+
+      upsertNote(db, {
+        path: "Projects/Alpha.md",
+        noteId: "alpha",
+        created: null,
+        title: "Alpha",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+      upsertNote(db, {
+        path: "Projects/Beta.md",
+        noteId: "beta",
+        created: null,
+        title: "Beta",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+      upsertNote(db, {
+        path: "Personal/Gamma.md",
+        noteId: "gamma",
+        created: null,
+        title: "Gamma",
+        summary: null,
+        entity: null,
+        layer: null,
+        status: null,
+        updated: null,
+        frontmatterJson: "{}",
+      });
+
+      replaceNoteTags(db, "Projects/Alpha.md", ["project"]);
+      replaceNoteTags(db, "Projects/Beta.md", ["project", "urgent"]);
+      replaceNoteTags(db, "Personal/Gamma.md", ["urgent", "personal"]);
+
+      insertChunkWithEmbedding(db, {
+        chunkId: "alpha",
+        path: "Projects/Alpha.md",
+        chunkIndex: 0,
+        heading: "Alpha",
+        headingPathJson: JSON.stringify(["Alpha"]),
+        content: "alpha",
+        contentSha256: "sha-alpha",
+        embedding: [0.3, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "beta",
+        path: "Projects/Beta.md",
+        chunkIndex: 0,
+        heading: "Beta",
+        headingPathJson: JSON.stringify(["Beta"]),
+        content: "beta",
+        contentSha256: "sha-beta",
+        embedding: [0.2, 0, 0],
+      });
+      insertChunkWithEmbedding(db, {
+        chunkId: "gamma",
+        path: "Personal/Gamma.md",
+        chunkIndex: 0,
+        heading: "Gamma",
+        headingPathJson: JSON.stringify(["Gamma"]),
+        content: "gamma",
+        contentSha256: "sha-gamma",
+        embedding: [0, 0, 0],
+      });
+
+      const { close, url } = await startAilssMcpHttpServer({
+        runtime,
+        config: { host: "127.0.0.1", port: 0, path: "/mcp", token: TEST_TOKEN },
+        maxSessions: 5,
+        idleTtlMs: 60_000,
+      });
+
+      try {
+        const sessionId = await mcpInitialize(url, TEST_TOKEN, "client-a");
+        const res = await mcpToolsCall(url, TEST_TOKEN, sessionId, "get_context", {
+          query: "query",
+          path_prefix: "Projects/",
+          tags_any: ["urgent"],
+          tags_all: ["project"],
+          top_k: 3,
+          expand_top_k: 0,
+        });
+
+        throwIfToolCallFailed(res);
+        const structured = getStructuredContent(res);
+        expect(structured["applied_filters"]).toEqual({
+          path_prefix: "Projects/",
+          tags_any: ["urgent"],
+          tags_all: ["project"],
+        });
+
+        const results = structured["results"] as Array<Record<string, unknown>>;
+        expect(results).toHaveLength(1);
+        expect(results[0]?.path).toBe("Projects/Beta.md");
       } finally {
         await close();
         db.close();


### PR DESCRIPTION
## What

- Add optional scoped candidate filters to `semanticSearch` in core: `pathPrefix`, `tagsAny`, `tagsAll`
- Extend `get_context` input with `path_prefix`, `tags_any`, `tags_all` and pass them into scoped semantic retrieval
- Add `applied_filters` to `get_context` response metadata for retrieval observability
- Add/extend tests in core and mcp to verify filter behavior and metadata

## Why

- `get_context` currently searches across the full vault, which can mix unrelated projects in larger vaults
- Scoped candidate filtering improves project-specific retrieval precision while keeping backward compatibility when no filters are provided

- Fixes #79

## How

- Build SQL candidate predicates from optional path/tag filters and apply them as rowid constraints before vector ranking
- Keep existing over-fetch and dedupe-by-path behavior unchanged after filtered semantic results are returned
- Validate behavior with new tests for unscoped vs scoped ranking and MCP response metadata
