### PR TITLE
docs: add refactor issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,34 @@
+---
+name: Refactor (Markdown)
+about: Improve code structure without changing user-visible behavior (Markdown template)
+title: "refactor: "
+labels: ["refactor"]
+---
+
+Use this template for structural/code-quality improvements.
+Please avoid adding component/scope to the title (no `refactor(core): ...`, no `mcp: ...`).
+Use labels for component tagging instead.
+
+## Problem statement
+
+What makes the current structure difficult to maintain?
+
+## Refactor goal
+
+What structure should be improved?
+
+## In scope
+
+What is included in this refactor?
+
+## Out of scope
+
+What must stay unchanged? (for example: no schema/public API/CLI behavior change)
+
+## Validation
+
+Which checks/tests confirm behavior is preserved?
+
+## Done criteria
+
+What defines completion?

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,65 @@
+name: Refactor
+description: Improve code structure without changing user-visible behavior
+title: "refactor: "
+labels: ["refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for structural/code-quality improvements.
+        Please avoid adding component/scope to the title (no `refactor(core): ...`, no `mcp: ...`).
+        Use labels for component tagging instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What makes the current structure difficult to maintain?
+      placeholder: "This module mixes A/B/C concerns and changes are risky because ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Refactor goal
+      description: What structure should be improved?
+      placeholder: "Split by concern, reduce duplication, isolate side effects, ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In scope
+      description: What is included in this refactor?
+      placeholder: "- File/module boundaries\n- Function/class extraction\n- Internal naming cleanup"
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What must stay unchanged?
+      placeholder: "- No schema change\n- No public API/CLI behavior change\n- No user-visible UX change"
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Which checks/tests will confirm behavior is preserved?
+      placeholder: "- pnpm --filter @ailss/core test\n- pnpm --filter @ailss/mcp test"
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_criteria
+    attributes:
+      label: Done criteria
+      description: What defines completion?
+      placeholder: "- Public behavior unchanged\n- Existing tests pass\n- Code paths are easier to navigate"
+    validations:
+      required: true


### PR DESCRIPTION
## What

- Add new issue form template: `.github/ISSUE_TEMPLATE/refactor.yml`
- Add new markdown issue template: `.github/ISSUE_TEMPLATE/refactor.md`
- Set default title prefix to `refactor: ` and default label to `refactor`
- Add required sections to enforce structural-refactor scope (`Problem statement`, `Refactor goal`, `In scope`, `Out of scope`, `Validation`, `Done criteria`)

## Why

- Standardize refactor issue intake so refactor work is tracked separately from feature requests
- Enforce the team's policy to use `refactor` as a standalone type/label for behavior-preserving structural work
- Reduce ambiguity in triage by making non-goals explicit (`Out of scope`)

## How

- Follow the existing issue-template conventions and add a dedicated `refactor` pair (`.yml` + `.md`)
- Keep changes minimal and limited to issue templates only
- Validation:
- Not run: repository checks require workspace dependencies (`prettier`/`pnpm check`), but this environment has no `node_modules`
