### PR TITLE
docs: add issue template mapping guidance to AGENTS

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -2,7 +2,7 @@
 name: Documentation issue (Markdown)
 about: Report missing/incorrect docs (Markdown template)
 title: "docs: "
-labels: ["documentation"]
+labels: ["docs"]
 ---
 
 Please avoid adding component/scope to the title (no `docs(ops): ...`, no `mcp: ...`).

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,7 +1,7 @@
 name: Documentation issue
 description: Report missing/incorrect docs
 title: "docs: "
-labels: ["documentation"]
+labels: ["docs"]
 body:
   - type: markdown
     attributes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,12 @@ When filing an issue, optimize for fast, high-confidence triage.
 
 - Title: concise, specific, and action-oriented (avoid vague titles like “It doesn’t work”).
 - Prefer using the Issue templates under `.github/ISSUE_TEMPLATE/` (they standardize title prefixes and required fields).
+- Template mapping (recommended):
+  - `feature-request` template → `feat: ...` title + `enhancement` label
+  - `bug-report` template → `bug: ...` title + `bug` label
+  - `docs` template → `docs: ...` title + `docs` label
+  - `question` template → `question: ...` title + `question` label
+  - `refactor` template → `refactor: ...` title + `refactor` label (do not combine with `enhancement`)
 - Avoid encoding component or scope in the title (no `type(scope): ...` and no `component: ...` prefixes); use labels (and template fields when present) instead.
 - Problem statement: what you were trying to do and why.
 - Reproduction: numbered steps starting from a clean state; include minimal config/snippets when possible.


### PR DESCRIPTION
## What

- Add explicit issue-template mapping guidance in `AGENTS.md`
- Document how each template maps to title prefix + type label
- Clarify that `refactor` issues use `refactor` label only (no `enhancement`)

## Why

- Keep issue filing consistent with newly introduced `refactor` template
- Reduce ambiguity when choosing issue template/title/label combinations
- Align workspace and repository issue operations with current triage policy

## How

- Update the GitHub issue conventions section in `AGENTS.md`
- Add a concise, template-by-template mapping list
- Validation:
- Not run: repository checks require workspace dependencies (`prettier`/`pnpm check`), but this environment has no `node_modules`
