### PR TITLE
refactor: split get_context orchestration into focused helpers

### DIFF
--- a/packages/mcp/src/tools/getContext.ts
+++ b/packages/mcp/src/tools/getContext.ts
@@ -51,6 +51,44 @@ type RetrievalPlan = {
   ordered: OrderedHitRow[];
 };
 
+type ToolResultRow = {
+  path: string;
+  distance: number;
+  title: string | null;
+  summary: string | null;
+  tags: string[];
+  keywords: string[];
+  heading: string | null;
+  heading_path: string[];
+  snippet: string;
+  evidence_text: string | null;
+  evidence_truncated: boolean;
+  evidence_chunks: EvidenceChunk[];
+  preview: string | null;
+  preview_truncated: boolean;
+};
+
+type CompositionParams = {
+  expandTopK: number;
+  neighborWindow: number;
+  perNoteEvidenceChars: number;
+  includePreview: boolean;
+  maxCharsPerNote: number;
+  maxTotalEvidenceChars: number;
+};
+
+type EvidenceComposition = {
+  text: string | null;
+  truncated: boolean;
+  chunks: EvidenceChunk[];
+  usedChars: number;
+};
+
+type PreviewComposition = {
+  preview: string | null;
+  previewTruncated: boolean;
+};
+
 export function registerGetContextTool(server: McpServer, deps: McpToolDeps): void {
   const defaultTopK = parseDefaultTopKFromEnv(process.env.AILSS_GET_CONTEXT_DEFAULT_TOP_K);
 
@@ -74,137 +112,31 @@ export function registerGetContextTool(server: McpServer, deps: McpToolDeps): vo
         topK: args.top_k,
         hitChunksPerNote: args.hit_chunks_per_note,
       });
-
-      const results: Array<{
-        path: string;
-        distance: number;
-        title: string | null;
-        summary: string | null;
-        tags: string[];
-        keywords: string[];
-        heading: string | null;
-        heading_path: string[];
-        snippet: string;
-        evidence_text: string | null;
-        evidence_truncated: boolean;
-        evidence_chunks: EvidenceChunk[];
-        preview: string | null;
-        preview_truncated: boolean;
-      }> = [];
-
-      const expandTopK = Math.max(0, Math.min(args.expand_top_k, desiredNotes));
-      const neighborWindow = Math.max(0, Math.min(args.neighbor_window, 3));
-      const perNoteEvidenceChars = Math.max(
-        200,
-        Math.min(args.max_evidence_chars_per_note, 20_000),
-      );
-      const includePreview = Boolean(args.include_file_preview && deps.vaultPath);
-
-      const maxTotalEvidenceChars = expandTopK * perNoteEvidenceChars;
-      let usedTotalEvidenceChars = 0;
-
-      for (const [rank, row] of ordered.entries()) {
-        const best = row.best;
-        if (!best) continue;
-
-        const meta = getNoteMeta(deps.db, row.path);
-        const title = meta?.title ?? null;
-        const summary = meta?.summary ?? null;
-        const tags = meta?.tags ?? [];
-        const keywords = meta?.keywords ?? [];
-
-        let evidenceText: string | null = null;
-        let evidenceTruncated = false;
-        let evidenceChunks: EvidenceChunk[] = [];
-
-        if (rank < expandTopK && usedTotalEvidenceChars < maxTotalEvidenceChars) {
-          const remainingGlobal = maxTotalEvidenceChars - usedTotalEvidenceChars;
-          const maxChars = Math.max(200, Math.min(perNoteEvidenceChars, remainingGlobal));
-
-          const wantedIndices = new Set<number>();
-          for (let d = -neighborWindow; d <= neighborWindow; d += 1) {
-            wantedIndices.add(best.chunkIndex + d);
-          }
-
-          for (const extra of row.hits.slice(1)) {
-            wantedIndices.add(extra.chunkIndex);
-          }
-
-          const chunks = listChunksByPathAndIndices(deps.db, row.path, Array.from(wantedIndices));
-
-          const hitChunkIds = new Set(row.hits.map((h) => h.chunkId));
-          const distanceByChunkId = new Map<string, number>();
-          for (const h of row.hits) {
-            distanceByChunkId.set(h.chunkId, h.distance);
-          }
-
-          const stitched = stitchChunkContents(chunks, maxChars);
-          evidenceText = stitched.text;
-          evidenceTruncated = stitched.truncated;
-          usedTotalEvidenceChars += stitched.text.length;
-
-          const usedChunkIds = new Set(stitched.used_chunk_ids);
-          evidenceChunks = chunks
-            .filter((c) => usedChunkIds.has(c.chunkId))
-            .map((c) => ({
-              chunk_id: c.chunkId,
-              chunk_index: c.chunkIndex,
-              kind: hitChunkIds.has(c.chunkId) ? "hit" : "neighbor",
-              distance: distanceByChunkId.get(c.chunkId) ?? null,
-              heading: c.heading,
-              heading_path: c.headingPath,
-            }));
-        }
-
-        const snippetSource = evidenceText ?? best.content;
-        const snippet = snippetSource.slice(0, 300);
-
-        let preview: string | null = null;
-        let previewTruncated = false;
-        if (includePreview && deps.vaultPath) {
-          const { text, truncated } = await readVaultFileText({
-            vaultPath: deps.vaultPath,
-            vaultRelPath: row.path,
-            maxChars: args.max_chars_per_note,
-          });
-          preview = text;
-          previewTruncated = truncated;
-        }
-
-        results.push({
-          path: row.path,
-          distance: best.distance,
-          title,
-          summary,
-          tags,
-          keywords,
-          heading: best.heading,
-          heading_path: best.headingPath,
-          snippet,
-          evidence_text: evidenceText,
-          evidence_truncated: evidenceTruncated,
-          evidence_chunks: evidenceChunks,
-          preview,
-          preview_truncated: previewTruncated,
-        });
-      }
-
-      const payload = {
+      const composition = buildCompositionParams({
+        desiredNotes,
+        expandTopK: args.expand_top_k,
+        neighborWindow: args.neighbor_window,
+        maxEvidenceCharsPerNote: args.max_evidence_chars_per_note,
+        includeFilePreview: args.include_file_preview,
+        hasVaultPath: Boolean(deps.vaultPath),
+        maxCharsPerNote: args.max_chars_per_note,
+      });
+      const results = await composeResultRows({
+        db: deps.db,
+        ordered,
+        vaultPath: deps.vaultPath,
+        composition,
+      });
+      const payload = buildPayload({
         query: args.query,
-        top_k: args.top_k,
-        db: deps.dbPath,
-        used_chunks_k: usedChunksK,
-        applied_filters: appliedFilters,
-        params: {
-          expand_top_k: expandTopK,
-          hit_chunks_per_note: hitChunksPerNote,
-          neighbor_window: neighborWindow,
-          max_evidence_chars_per_note: perNoteEvidenceChars,
-          include_file_preview: includePreview,
-          max_chars_per_note: args.max_chars_per_note,
-        },
+        topK: args.top_k,
+        dbPath: deps.dbPath,
+        usedChunksK,
+        appliedFilters,
+        hitChunksPerNote,
+        composition,
         results,
-      };
+      });
 
       return {
         structuredContent: payload,
@@ -428,6 +360,195 @@ function buildOrderedRows(
     .filter((row): row is OrderedHitRow => Boolean(row.best))
     .sort((a, b) => a.best.distance - b.best.distance)
     .slice(0, desiredNotes);
+}
+
+function buildCompositionParams(params: {
+  desiredNotes: number;
+  expandTopK: number;
+  neighborWindow: number;
+  maxEvidenceCharsPerNote: number;
+  includeFilePreview: boolean;
+  hasVaultPath: boolean;
+  maxCharsPerNote: number;
+}): CompositionParams {
+  const expandTopK = Math.max(0, Math.min(params.expandTopK, params.desiredNotes));
+  const neighborWindow = Math.max(0, Math.min(params.neighborWindow, 3));
+  const perNoteEvidenceChars = Math.max(200, Math.min(params.maxEvidenceCharsPerNote, 20_000));
+  const includePreview = Boolean(params.includeFilePreview && params.hasVaultPath);
+
+  return {
+    expandTopK,
+    neighborWindow,
+    perNoteEvidenceChars,
+    includePreview,
+    maxCharsPerNote: params.maxCharsPerNote,
+    maxTotalEvidenceChars: expandTopK * perNoteEvidenceChars,
+  };
+}
+
+async function composeResultRows(params: {
+  db: McpToolDeps["db"];
+  ordered: OrderedHitRow[];
+  vaultPath: string | undefined;
+  composition: CompositionParams;
+}): Promise<ToolResultRow[]> {
+  const results: ToolResultRow[] = [];
+  let usedTotalEvidenceChars = 0;
+
+  for (const [rank, row] of params.ordered.entries()) {
+    const meta = getNoteMeta(params.db, row.path);
+    let evidence: EvidenceComposition = { text: null, truncated: false, chunks: [], usedChars: 0 };
+
+    if (
+      rank < params.composition.expandTopK &&
+      usedTotalEvidenceChars < params.composition.maxTotalEvidenceChars
+    ) {
+      const remainingGlobal = params.composition.maxTotalEvidenceChars - usedTotalEvidenceChars;
+      const maxChars = Math.max(
+        200,
+        Math.min(params.composition.perNoteEvidenceChars, remainingGlobal),
+      );
+      evidence = composeEvidenceForRow({
+        db: params.db,
+        row,
+        neighborWindow: params.composition.neighborWindow,
+        maxChars,
+      });
+      usedTotalEvidenceChars += evidence.usedChars;
+    }
+
+    const preview = await composePreviewForRow({
+      includePreview: params.composition.includePreview,
+      vaultPath: params.vaultPath,
+      path: row.path,
+      maxCharsPerNote: params.composition.maxCharsPerNote,
+    });
+
+    results.push(
+      buildResultRow({
+        row,
+        meta,
+        evidence,
+        preview,
+      }),
+    );
+  }
+
+  return results;
+}
+
+function composeEvidenceForRow(params: {
+  db: McpToolDeps["db"];
+  row: OrderedHitRow;
+  neighborWindow: number;
+  maxChars: number;
+}): EvidenceComposition {
+  const wantedIndices = new Set<number>();
+  for (let d = -params.neighborWindow; d <= params.neighborWindow; d += 1) {
+    wantedIndices.add(params.row.best.chunkIndex + d);
+  }
+  for (const extra of params.row.hits.slice(1)) {
+    wantedIndices.add(extra.chunkIndex);
+  }
+
+  const chunks = listChunksByPathAndIndices(params.db, params.row.path, Array.from(wantedIndices));
+
+  const hitChunkIds = new Set(params.row.hits.map((h) => h.chunkId));
+  const distanceByChunkId = new Map<string, number>();
+  for (const h of params.row.hits) {
+    distanceByChunkId.set(h.chunkId, h.distance);
+  }
+
+  const stitched = stitchChunkContents(chunks, params.maxChars);
+  const usedChunkIds = new Set(stitched.used_chunk_ids);
+  const evidenceChunks: EvidenceChunk[] = chunks
+    .filter((c) => usedChunkIds.has(c.chunkId))
+    .map((c) => ({
+      chunk_id: c.chunkId,
+      chunk_index: c.chunkIndex,
+      kind: hitChunkIds.has(c.chunkId) ? "hit" : "neighbor",
+      distance: distanceByChunkId.get(c.chunkId) ?? null,
+      heading: c.heading,
+      heading_path: c.headingPath,
+    }));
+
+  return {
+    text: stitched.text,
+    truncated: stitched.truncated,
+    chunks: evidenceChunks,
+    usedChars: stitched.text.length,
+  };
+}
+
+async function composePreviewForRow(params: {
+  includePreview: boolean;
+  vaultPath: string | undefined;
+  path: string;
+  maxCharsPerNote: number;
+}): Promise<PreviewComposition> {
+  if (!params.includePreview || !params.vaultPath) {
+    return { preview: null, previewTruncated: false };
+  }
+
+  const { text, truncated } = await readVaultFileText({
+    vaultPath: params.vaultPath,
+    vaultRelPath: params.path,
+    maxChars: params.maxCharsPerNote,
+  });
+  return { preview: text, previewTruncated: truncated };
+}
+
+function buildResultRow(params: {
+  row: OrderedHitRow;
+  meta: ReturnType<typeof getNoteMeta>;
+  evidence: EvidenceComposition;
+  preview: PreviewComposition;
+}): ToolResultRow {
+  const snippetSource = params.evidence.text ?? params.row.best.content;
+  return {
+    path: params.row.path,
+    distance: params.row.best.distance,
+    title: params.meta?.title ?? null,
+    summary: params.meta?.summary ?? null,
+    tags: params.meta?.tags ?? [],
+    keywords: params.meta?.keywords ?? [],
+    heading: params.row.best.heading,
+    heading_path: params.row.best.headingPath,
+    snippet: snippetSource.slice(0, 300),
+    evidence_text: params.evidence.text,
+    evidence_truncated: params.evidence.truncated,
+    evidence_chunks: params.evidence.chunks,
+    preview: params.preview.preview,
+    preview_truncated: params.preview.previewTruncated,
+  };
+}
+
+function buildPayload(params: {
+  query: string;
+  topK: number;
+  dbPath: string;
+  usedChunksK: number;
+  appliedFilters: AppliedFilters;
+  hitChunksPerNote: number;
+  composition: CompositionParams;
+  results: ToolResultRow[];
+}) {
+  return {
+    query: params.query,
+    top_k: params.topK,
+    db: params.dbPath,
+    used_chunks_k: params.usedChunksK,
+    applied_filters: params.appliedFilters,
+    params: {
+      expand_top_k: params.composition.expandTopK,
+      hit_chunks_per_note: params.hitChunksPerNote,
+      neighbor_window: params.composition.neighborWindow,
+      max_evidence_chars_per_note: params.composition.perNoteEvidenceChars,
+      include_file_preview: params.composition.includePreview,
+      max_chars_per_note: params.composition.maxCharsPerNote,
+    },
+    results: params.results,
+  };
 }
 
 function stitchChunkContents(


### PR DESCRIPTION
## What

- Refactored `packages/mcp/src/tools/getContext.ts` to separate schema definition, retrieval planning, evidence/preview composition, and payload mapping helpers.
- Kept the `get_context` tool name, input/output schemas, and response field semantics unchanged.

## Why

- Reduced mixed concerns in a single registration flow so future ranking/output changes are lower risk.
- Fixes #86

## How

- Added schema builder helpers: `buildGetContextInputSchema`, `buildGetContextOutputSchema`.
- Added retrieval helpers: `buildAppliedFilters`, `buildSemanticFilters`, `planRetrieval`, `overfetchChunkHits`, `buildOrderedRows`.
- Added composition helpers: `buildCompositionParams`, `composeResultRows`, `composeEvidenceForRow`, `composePreviewForRow`, `buildResultRow`, `buildPayload`.
- Validation run: `pnpm --filter @ailss/mcp typecheck`, `pnpm --filter @ailss/mcp build`, `pnpm test`.
