### PR TITLE
refactor: split vault indexing pipeline into staged helpers

### DIFF
--- a/packages/core/src/indexing/indexVault.ts
+++ b/packages/core/src/indexing/indexVault.ts
@@ -197,6 +197,130 @@ async function syncFileMetadataStage(
   return parsed.body;
 }
 
+type ChunkDiffPlan = {
+  plannedChunks: PlannedChunk[];
+  existingChunkIds: Set<string>;
+  toDelete: string[];
+  embeddingByContentSha: Map<string, number[]>;
+  toEmbed: Array<{ contentSha256: string; content: string }>;
+};
+
+function planChunkDiffStage(
+  db: AilssDb,
+  fileRelPath: string,
+  body: string,
+  maxChars: number,
+): ChunkDiffPlan {
+  const chunks = chunkMarkdownByHeadings(body, { maxChars });
+  const plannedChunks = computeStableChunkIds(fileRelPath, chunks);
+
+  const existingChunkIds = new Set(listChunkIdsByPath(db, fileRelPath));
+  const nextChunkIds = new Set(plannedChunks.map((chunk) => chunk.chunkId));
+
+  const toDelete: string[] = [];
+  for (const chunkId of existingChunkIds) {
+    if (!nextChunkIds.has(chunkId)) toDelete.push(chunkId);
+  }
+
+  const embeddingByContentSha = new Map<string, number[]>();
+  for (const item of listChunkEmbeddingsByPath(db, fileRelPath)) {
+    if (!embeddingByContentSha.has(item.contentSha256)) {
+      embeddingByContentSha.set(item.contentSha256, item.embedding);
+    }
+  }
+
+  const toEmbed: Array<{ contentSha256: string; content: string }> = [];
+  const seenToEmbed = new Set<string>();
+  for (const planned of plannedChunks) {
+    if (existingChunkIds.has(planned.chunkId)) continue;
+    if (embeddingByContentSha.has(planned.contentSha256)) continue;
+    if (seenToEmbed.has(planned.contentSha256)) continue;
+    seenToEmbed.add(planned.contentSha256);
+    toEmbed.push({ contentSha256: planned.contentSha256, content: planned.content });
+  }
+
+  return {
+    plannedChunks,
+    existingChunkIds,
+    toDelete,
+    embeddingByContentSha,
+    toEmbed,
+  };
+}
+
+function applyChunkDeleteStage(db: AilssDb, toDelete: string[]): void {
+  if (toDelete.length === 0) return;
+  deleteChunksByIds(db, toDelete);
+}
+
+async function acquireChunkEmbeddingsStage(
+  options: IndexVaultOptions,
+  plan: ChunkDiffPlan,
+  batchSize: number,
+): Promise<void> {
+  for (let i = 0; i < plan.toEmbed.length; i += batchSize) {
+    const batch = plan.toEmbed.slice(i, i + batchSize);
+    const embeddings = await options.embedTexts(batch.map((chunk) => chunk.content));
+
+    for (const [j, chunk] of batch.entries()) {
+      const embedding = embeddings[j];
+      if (!embedding) {
+        throw new Error(
+          `Embedding response returned too few embeddings. batchSize=${batch.length}, got=${embeddings.length}`,
+        );
+      }
+      plan.embeddingByContentSha.set(chunk.contentSha256, embedding);
+    }
+
+    writeText(
+      options.logger,
+      `[chunks] ${Math.min(i + batch.length, plan.toEmbed.length)}/${plan.toEmbed.length}\r`,
+    );
+  }
+
+  writeText(options.logger, "\n");
+}
+
+function applyChunkWriteStage(
+  options: IndexVaultOptions,
+  fileRelPath: string,
+  plan: ChunkDiffPlan,
+): void {
+  for (const planned of plan.plannedChunks) {
+    if (!plan.existingChunkIds.has(planned.chunkId)) continue;
+    updateChunkMetadata(options.db, {
+      chunkId: planned.chunkId,
+      path: fileRelPath,
+      chunkIndex: planned.chunkIndex,
+      heading: planned.heading,
+      headingPathJson: planned.headingPathJson,
+      content: planned.content,
+      contentSha256: planned.contentSha256,
+    });
+  }
+
+  for (const planned of plan.plannedChunks) {
+    if (plan.existingChunkIds.has(planned.chunkId)) continue;
+    const embedding = plan.embeddingByContentSha.get(planned.contentSha256);
+    if (!embedding) {
+      throw new Error(
+        `Missing embedding for chunk insertion. path=${fileRelPath}, contentSha256=${planned.contentSha256}`,
+      );
+    }
+
+    insertChunkWithEmbedding(options.db, {
+      chunkId: planned.chunkId,
+      path: fileRelPath,
+      chunkIndex: planned.chunkIndex,
+      heading: planned.heading,
+      headingPathJson: planned.headingPathJson,
+      content: planned.content,
+      contentSha256: planned.contentSha256,
+      embedding,
+    });
+  }
+}
+
 export async function indexVault(options: IndexVaultOptions): Promise<IndexVaultSummary> {
   const maxChars = Math.max(1, options.maxChars ?? 4000);
   const batchSize = Math.max(1, options.batchSize ?? 32);
@@ -231,106 +355,18 @@ export async function indexVault(options: IndexVaultOptions): Promise<IndexVault
     }
 
     const body = await syncFileMetadataStage(options, file);
-    const chunks = needsEmbeddingUpdate ? chunkMarkdownByHeadings(body, { maxChars }) : [];
 
     if (!needsEmbeddingUpdate) {
       continue;
     }
 
-    const plannedChunks = computeStableChunkIds(file.relPath, chunks);
+    const plan = planChunkDiffStage(options.db, file.relPath, body, maxChars);
+    applyChunkDeleteStage(options.db, plan.toDelete);
+    await acquireChunkEmbeddingsStage(options, plan, batchSize);
+    applyChunkWriteStage(options, file.relPath, plan);
 
-    const existingChunkIds = new Set(listChunkIdsByPath(options.db, file.relPath));
-    const nextChunkIds = new Set(plannedChunks.map((c) => c.chunkId));
-
-    const toDelete: string[] = [];
-    for (const chunkId of existingChunkIds) {
-      if (!nextChunkIds.has(chunkId)) toDelete.push(chunkId);
-    }
-
-    // Embedding cache by content hash
-    // - allows per-chunk reuse even when chunk IDs change (e.g. heading rename)
-    const embeddingByContentSha = new Map<string, number[]>();
-    for (const item of listChunkEmbeddingsByPath(options.db, file.relPath)) {
-      if (!embeddingByContentSha.has(item.contentSha256)) {
-        embeddingByContentSha.set(item.contentSha256, item.embedding);
-      }
-    }
-
-    // Plan which new chunk contents need embedding calls (deduped)
-    const toEmbed: Array<{ contentSha256: string; content: string }> = [];
-    const seenToEmbed = new Set<string>();
-    for (const planned of plannedChunks) {
-      if (existingChunkIds.has(planned.chunkId)) continue;
-      if (embeddingByContentSha.has(planned.contentSha256)) continue;
-      if (seenToEmbed.has(planned.contentSha256)) continue;
-      seenToEmbed.add(planned.contentSha256);
-      toEmbed.push({ contentSha256: planned.contentSha256, content: planned.content });
-    }
-
-    if (toDelete.length > 0) {
-      deleteChunksByIds(options.db, toDelete);
-    }
-
-    for (let i = 0; i < toEmbed.length; i += batchSize) {
-      const batch = toEmbed.slice(i, i + batchSize);
-      const embeddings = await options.embedTexts(batch.map((c) => c.content));
-
-      for (const [j, chunk] of batch.entries()) {
-        const embedding = embeddings[j];
-        if (!embedding) {
-          throw new Error(
-            `Embedding response returned too few embeddings. batchSize=${batch.length}, got=${embeddings.length}`,
-          );
-        }
-        embeddingByContentSha.set(chunk.contentSha256, embedding);
-      }
-
-      writeText(
-        options.logger,
-        `[chunks] ${Math.min(i + batch.length, toEmbed.length)}/${toEmbed.length}\r`,
-      );
-    }
-
-    writeText(options.logger, "\n");
-
-    // Update existing chunk metadata without touching embeddings
-    for (const planned of plannedChunks) {
-      if (!existingChunkIds.has(planned.chunkId)) continue;
-      updateChunkMetadata(options.db, {
-        chunkId: planned.chunkId,
-        path: file.relPath,
-        chunkIndex: planned.chunkIndex,
-        heading: planned.heading,
-        headingPathJson: planned.headingPathJson,
-        content: planned.content,
-        contentSha256: planned.contentSha256,
-      });
-    }
-
-    // Insert new chunks with embeddings (reused or freshly embedded)
-    for (const planned of plannedChunks) {
-      if (existingChunkIds.has(planned.chunkId)) continue;
-      const embedding = embeddingByContentSha.get(planned.contentSha256);
-      if (!embedding) {
-        throw new Error(
-          `Missing embedding for chunk insertion. path=${file.relPath}, contentSha256=${planned.contentSha256}`,
-        );
-      }
-
-      insertChunkWithEmbedding(options.db, {
-        chunkId: planned.chunkId,
-        path: file.relPath,
-        chunkIndex: planned.chunkIndex,
-        heading: planned.heading,
-        headingPathJson: planned.headingPathJson,
-        content: planned.content,
-        contentSha256: planned.contentSha256,
-        embedding,
-      });
-    }
-
-    indexedChunks += plannedChunks.length;
-    logLine(options.logger, `[done] chunks=${plannedChunks.length}`);
+    indexedChunks += plan.plannedChunks.length;
+    logLine(options.logger, `[done] chunks=${plan.plannedChunks.length}`);
   }
 
   if (existingRelPaths) {

--- a/packages/core/test/indexVault.chunk-reuse.test.ts
+++ b/packages/core/test/indexVault.chunk-reuse.test.ts
@@ -113,4 +113,139 @@ describe("indexVault() per-chunk reuse", () => {
       }
     });
   });
+
+  it("keeps chunk operation order: delete before embed, write after embed", async () => {
+    await withTempDir("ailss-core-", async (dir) => {
+      const vaultPath = path.join(dir, "vault");
+      await fs.mkdir(vaultPath, { recursive: true });
+
+      const notePath = path.join(vaultPath, "Note.md");
+      await fs.writeFile(
+        notePath,
+        [
+          "---",
+          'id: "20260108123456"',
+          'created: "2026-01-08T12:34:56"',
+          'title: "Note"',
+          "---",
+          "",
+          "# A",
+          "alpha",
+          "",
+          "# B",
+          "bravo",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const dbPath = path.join(dir, "index.sqlite");
+      const db = openAilssDb({ dbPath, embeddingModel: "test-embeddings", embeddingDim: 3 });
+
+      try {
+        await indexVault({
+          db,
+          vaultPath,
+          embeddingModel: "test-embeddings",
+          embedTexts: async (inputs: string[]): Promise<number[][]> =>
+            inputs.map((_, i) => [0.1 + i, 0.2 + i, 0.3 + i]),
+          maxChars: 4000,
+          batchSize: 32,
+        });
+
+        const oldA = db
+          .prepare(
+            "SELECT chunk_id as chunkId, chunk_index as chunkIndex FROM chunks WHERE path = ? AND content = ?",
+          )
+          .get("Note.md", "# A\nalpha") as { chunkId: string; chunkIndex: number } | undefined;
+        const oldB = db
+          .prepare(
+            "SELECT chunk_id as chunkId, chunk_index as chunkIndex FROM chunks WHERE path = ? AND content = ?",
+          )
+          .get("Note.md", "# B\nbravo") as { chunkId: string; chunkIndex: number } | undefined;
+
+        if (!oldA || !oldB) {
+          throw new Error("expected baseline chunks for order regression test");
+        }
+
+        expect(oldA.chunkIndex).toBe(0);
+        expect(oldB.chunkIndex).toBe(1);
+
+        await fs.writeFile(
+          notePath,
+          [
+            "---",
+            'id: "20260108123456"',
+            'created: "2026-01-08T12:34:56"',
+            'title: "Note"',
+            "---",
+            "",
+            "# B",
+            "bravo!",
+            "",
+            "# A",
+            "alpha",
+            "",
+          ].join("\n"),
+          "utf8",
+        );
+
+        const embedCalls: string[][] = [];
+        let embedPhase: {
+          oldBCount: number;
+          oldAChunkIndex: number | null;
+          newBCount: number;
+        } | null = null;
+        const embedTexts = async (inputs: string[]): Promise<number[][]> => {
+          embedCalls.push(inputs);
+
+          const oldBCount = db
+            .prepare("SELECT COUNT(*) as count FROM chunks WHERE chunk_id = ?")
+            .get(oldB.chunkId) as { count: number };
+          const oldAState = db
+            .prepare("SELECT chunk_index as chunkIndex FROM chunks WHERE chunk_id = ?")
+            .get(oldA.chunkId) as { chunkIndex: number } | undefined;
+          const newBCount = db
+            .prepare("SELECT COUNT(*) as count FROM chunks WHERE path = ? AND content = ?")
+            .get("Note.md", "# B\nbravo!") as { count: number };
+
+          embedPhase = {
+            oldBCount: oldBCount.count,
+            oldAChunkIndex: oldAState?.chunkIndex ?? null,
+            newBCount: newBCount.count,
+          };
+
+          return inputs.map((_, i) => [1.1 + i, 1.2 + i, 1.3 + i]);
+        };
+
+        const summary = await indexVault({
+          db,
+          vaultPath,
+          embeddingModel: "test-embeddings",
+          embedTexts,
+          paths: ["Note.md"],
+          maxChars: 4000,
+          batchSize: 32,
+        });
+
+        expect(summary.changedFiles).toBe(1);
+        expect(summary.indexedChunks).toBe(2);
+        expect(embedCalls).toEqual([["# B\nbravo!"]]);
+        expect(embedPhase).toEqual({ oldBCount: 0, oldAChunkIndex: 0, newBCount: 0 });
+
+        const finalChunks = db
+          .prepare(
+            "SELECT chunk_id as chunkId, chunk_index as chunkIndex, content FROM chunks WHERE path = ? ORDER BY chunk_index ASC",
+          )
+          .all("Note.md") as Array<{ chunkId: string; chunkIndex: number; content: string }>;
+
+        expect(finalChunks).toHaveLength(2);
+        expect(finalChunks.map((chunk) => chunk.content)).toEqual(["# B\nbravo!", "# A\nalpha"]);
+        expect(finalChunks[1]?.chunkId).toBe(oldA.chunkId);
+        expect(finalChunks.some((chunk) => chunk.chunkId === oldB.chunkId)).toBe(false);
+      } finally {
+        db.close();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What

- Extracted target path discovery into `resolveIndexTargetsStage()`.
- Extracted per-file metadata sync into `syncFileMetadataStage()`.
- Extracted chunk pipeline into staged helpers: `planChunkDiffStage()`, `applyChunkDeleteStage()`, `acquireChunkEmbeddingsStage()`, and `applyChunkWriteStage()`.
- Kept `indexVault(options)` contract and summary output unchanged (`changedFiles`, `indexedChunks`, `deletedFiles`).

## Why

- Reduce complexity in the `indexVault()` flow by separating responsibilities into explicit stages.
- Keep behavior stable while making future indexing changes safer to review.

- Fixes #83 (optional; delete if not applicable)

## How

- Preserved existing execution semantics, including partial-run skip behavior and full-vault metadata refresh behavior.
- Preserved chunk processing order (`delete` -> `embed` -> `update existing` -> `insert new`) and embedding reuse logic.
- Verified with:
  - `pnpm --filter @ailss/core typecheck`
  - `pnpm --filter @ailss/indexer typecheck`
  - `pnpm --filter @ailss/core build`
  - `pnpm --filter @ailss/indexer build`
  - `pnpm test`
