### PR TITLE
refactor: split streamable http server lifecycle by concern

### DIFF
--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -1,248 +1,22 @@
 // AILSS MCP server - Streamable HTTP server (localhost)
 // - intended to be hosted by the Obsidian plugin and consumed by Codex via URL + token
 
-import http, { IncomingMessage, ServerResponse } from "node:http";
-import { randomUUID } from "node:crypto";
+import http from "node:http";
 
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-
+import { createAilssMcpRuntimeFromEnv } from "./createAilssMcpServer.js";
 import {
-  createAilssMcpRuntimeFromEnv,
-  createAilssMcpServerFromRuntime,
-  type AilssMcpRuntime,
-} from "./createAilssMcpServer.js";
+  normalizeShutdownConfig,
+  parseHttpConfigFromEnv,
+  parseIdleTtlMsFromEnv,
+  parseMaxSessionsFromEnv,
+  requireLocalhostHost,
+  type StartHttpServerOptions,
+} from "./httpServerConfig.js";
+import { createHttpRequestHandler } from "./httpServerRoutes.js";
+import { McpSessionStore } from "./httpServerSessions.js";
 
-export type HttpConfig = {
-  host: string;
-  port: number;
-  path: string;
-  token: string;
-};
-
-export type StartHttpServerOptions = {
-  runtime: AilssMcpRuntime;
-  config: HttpConfig;
-  maxSessions?: number;
-  idleTtlMs?: number;
-  shutdown?: {
-    path?: string;
-    token: string;
-    exitProcess?: boolean;
-  };
-};
-
-type McpSession = {
-  sessionId: string;
-  server: McpServer;
-  transport: StreamableHTTPServerTransport;
-  createdAtMs: number;
-  lastSeenAtMs: number;
-};
-
-export function requireLocalhostHost(host: string): void {
-  if (host === "127.0.0.1") return;
-  if (host === "localhost") return;
-  if (host === "::1") return;
-  throw new Error(`Refusing to bind MCP HTTP server to non-localhost host: "${host}"`);
-}
-
-export function parseHttpConfigFromEnv(): HttpConfig {
-  const host = (process.env.AILSS_MCP_HTTP_HOST ?? "127.0.0.1").trim();
-  requireLocalhostHost(host);
-
-  const portRaw = (process.env.AILSS_MCP_HTTP_PORT ?? "31415").trim();
-  const port = Number.parseInt(portRaw, 10);
-  if (!Number.isFinite(port) || port < 1 || port > 65535) {
-    throw new Error(`Invalid AILSS_MCP_HTTP_PORT: "${portRaw}"`);
-  }
-
-  const pathRaw = (process.env.AILSS_MCP_HTTP_PATH ?? "/mcp").trim() || "/mcp";
-  const path = pathRaw.startsWith("/") ? pathRaw : `/${pathRaw}`;
-
-  const token = (process.env.AILSS_MCP_HTTP_TOKEN ?? process.env.AILSS_MCP_TOKEN ?? "").trim();
-  if (!token) {
-    throw new Error("Missing AILSS_MCP_HTTP_TOKEN. Refusing to start without auth.");
-  }
-
-  return { host, port, path, token };
-}
-
-function baseUrlForRequest(req: IncomingMessage, config: HttpConfig): URL {
-  const reqUrl = req.url ?? "/";
-  return new URL(reqUrl, `http://${config.host}:${config.port}`);
-}
-
-function extractBearerToken(req: IncomingMessage, url: URL): string | null {
-  const auth = req.headers.authorization;
-  if (typeof auth === "string") {
-    const m = auth.match(/^Bearer\s+(.+)$/i);
-    if (m?.[1]) return m[1].trim();
-  }
-
-  const headerToken = req.headers["x-ailss-token"];
-  if (typeof headerToken === "string" && headerToken.trim()) return headerToken.trim();
-
-  const queryToken = url.searchParams.get("token");
-  if (queryToken && queryToken.trim()) return queryToken.trim();
-
-  return null;
-}
-
-async function readJsonBody(req: IncomingMessage, limitBytes: number): Promise<unknown> {
-  return await new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
-    let total = 0;
-
-    req.on("data", (chunk: Buffer) => {
-      total += chunk.length;
-      if (total > limitBytes) {
-        reject(new Error("Request body too large."));
-        req.destroy();
-        return;
-      }
-      chunks.push(chunk);
-    });
-
-    req.on("end", () => {
-      if (chunks.length === 0) {
-        resolve(undefined);
-        return;
-      }
-
-      const text = Buffer.concat(chunks).toString("utf8").trim();
-      if (!text) {
-        resolve(undefined);
-        return;
-      }
-
-      try {
-        resolve(JSON.parse(text));
-      } catch {
-        reject(new Error("Invalid JSON body."));
-      }
-    });
-
-    req.on("error", (error) => reject(error));
-  });
-}
-
-function sendText(res: ServerResponse, code: number, message: string): void {
-  res.statusCode = code;
-  res.setHeader("content-type", "text/plain; charset=utf-8");
-  res.end(message);
-}
-
-function sendJsonRpcError(
-  res: ServerResponse,
-  code: number,
-  mcpErrorCode: number,
-  message: string,
-): void {
-  res.statusCode = code;
-  res.setHeader("content-type", "application/json; charset=utf-8");
-  res.end(
-    JSON.stringify({
-      jsonrpc: "2.0",
-      error: { code: mcpErrorCode, message },
-      id: null,
-    }),
-  );
-}
-
-function isInitializeRequestMessage(body: unknown): boolean {
-  if (!body) return false;
-  if (Array.isArray(body)) return body.some(isInitializeRequestMessage);
-  if (typeof body !== "object") return false;
-
-  const method = (body as { method?: unknown }).method;
-  return method === "initialize";
-}
-
-function getSingleHeaderValue(req: IncomingMessage, name: string): string | null | "multiple" {
-  const key = name.toLowerCase();
-
-  const distinct = req.headersDistinct?.[key];
-  if (Array.isArray(distinct)) {
-    if (distinct.length === 1) return distinct[0] ?? null;
-    if (distinct.length > 1) return "multiple";
-  }
-
-  const v = req.headers[key];
-  if (typeof v === "string") return v;
-  if (Array.isArray(v)) return "multiple";
-  return null;
-}
-
-function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "50").trim();
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 50;
-  return n;
-}
-
-function parseIdleTtlMsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_IDLE_TTL_MS ?? "3600000").trim();
-  const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) return 3_600_000;
-  return n;
-}
-
-function evictOldestSessions(sessions: Map<string, McpSession>, maxSessions: number): void {
-  while (sessions.size > maxSessions) {
-    let oldest: McpSession | null = null;
-    for (const s of sessions.values()) {
-      if (!oldest) oldest = s;
-      else if (s.lastSeenAtMs < oldest.lastSeenAtMs) oldest = s;
-    }
-
-    if (!oldest) return;
-    sessions.delete(oldest.sessionId);
-    oldest.transport.close().catch(() => {});
-    oldest.server.close().catch(() => {});
-  }
-}
-
-function closeIdleSessions(sessions: Map<string, McpSession>, idleTtlMs: number): void {
-  if (idleTtlMs <= 0) return;
-  const now = Date.now();
-
-  for (const [sessionId, session] of sessions.entries()) {
-    if (now - session.lastSeenAtMs <= idleTtlMs) continue;
-    sessions.delete(sessionId);
-    session.transport.close().catch(() => {});
-    session.server.close().catch(() => {});
-  }
-}
-
-async function createSession(
-  runtime: AilssMcpRuntime,
-  sessions: Map<string, McpSession>,
-  maxSessions: number,
-): Promise<{ server: McpServer; transport: StreamableHTTPServerTransport }> {
-  const { server } = createAilssMcpServerFromRuntime(runtime);
-  const transport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-    onsessioninitialized: (sessionId) => {
-      const now = Date.now();
-      sessions.set(sessionId, {
-        sessionId,
-        server,
-        transport,
-        createdAtMs: now,
-        lastSeenAtMs: now,
-      });
-      evictOldestSessions(sessions, maxSessions);
-    },
-    onsessionclosed: (sessionId) => {
-      sessions.delete(sessionId);
-    },
-  });
-
-  await server.connect(transport);
-  return { server, transport };
-}
+export type { HttpConfig, StartHttpServerOptions } from "./httpServerConfig.js";
+export { parseHttpConfigFromEnv, requireLocalhostHost } from "./httpServerConfig.js";
 
 export async function startAilssMcpHttpServer(options: StartHttpServerOptions): Promise<{
   httpServer: http.Server;
@@ -253,27 +27,36 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
 
   requireLocalhostHost(config.host);
 
-  const sessions = new Map<string, McpSession>();
   const maxSessions = options.maxSessions ?? parseMaxSessionsFromEnv();
   const idleTtlMs = options.idleTtlMs ?? parseIdleTtlMsFromEnv();
-  const shutdown =
-    options.shutdown && options.shutdown.token.trim()
-      ? {
-          path: (options.shutdown.path ?? "/__ailss/shutdown").startsWith("/")
-            ? (options.shutdown.path ?? "/__ailss/shutdown")
-            : `/${options.shutdown.path ?? "/__ailss/shutdown"}`,
-          token: options.shutdown.token.trim(),
-          exitProcess: options.shutdown.exitProcess ?? false,
-        }
-      : null;
+  const shutdown = normalizeShutdownConfig(options.shutdown);
+  const sessionStore = new McpSessionStore(maxSessions, idleTtlMs);
 
   let shuttingDown = false;
   let closePromise: Promise<void> | null = null;
 
-  const close = async (): Promise<void> => {
+  const startShuttingDown = (): void => {
+    shuttingDown = true;
+  };
+
+  const requestHandler = createHttpRequestHandler({
+    config,
+    runtime,
+    sessionStore,
+    shutdown,
+    isShuttingDown: () => shuttingDown,
+    startShuttingDown,
+    close,
+  });
+
+  const httpServer = http.createServer(async (req, res) => {
+    await requestHandler(req, res);
+  });
+
+  async function close(): Promise<void> {
     if (closePromise) return await closePromise;
 
-    shuttingDown = true;
+    startShuttingDown();
     closePromise = (async () => {
       const closeServer = new Promise<void>((resolve, reject) => {
         const onError = (error: unknown) => reject(error);
@@ -284,10 +67,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
         });
       });
 
-      const sessionClose = Promise.allSettled(
-        Array.from(sessions.values()).flatMap((s) => [s.transport.close(), s.server.close()]),
-      );
-      sessions.clear();
+      const sessionClose = sessionStore.closeAllSessions();
 
       // Close keep-alive sockets so the port is actually released.
       httpServer.closeIdleConnections();
@@ -315,123 +95,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
     })();
 
     return await closePromise;
-  };
-
-  const httpServer = http.createServer(async (req, res) => {
-    try {
-      const url = baseUrlForRequest(req, config);
-
-      if (url.pathname === "/health") {
-        sendText(res, 200, "ok");
-        return;
-      }
-
-      if (shutdown && url.pathname === shutdown.path) {
-        if (req.method !== "POST") {
-          sendText(res, 405, "method not allowed");
-          return;
-        }
-
-        const token = extractBearerToken(req, url);
-        if (token !== shutdown.token) {
-          sendText(res, 401, "unauthorized");
-          return;
-        }
-
-        if (shuttingDown) {
-          sendText(res, 200, "shutting down");
-          return;
-        }
-
-        shuttingDown = true;
-        sendText(res, 200, "shutting down");
-        setImmediate(() => {
-          void close().finally(() => {
-            if (shutdown.exitProcess) process.exit(0);
-          });
-        });
-        return;
-      }
-
-      if (shuttingDown) {
-        sendText(res, 503, "shutting down");
-        return;
-      }
-
-      if (url.pathname !== config.path) {
-        sendText(res, 404, "not found");
-        return;
-      }
-
-      const token = extractBearerToken(req, url);
-      if (token !== config.token) {
-        sendText(res, 401, "unauthorized");
-        return;
-      }
-
-      let parsedBody: unknown = undefined;
-      if (req.method === "POST") {
-        try {
-          parsedBody = await readJsonBody(req, 1_000_000);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "Bad request.";
-          sendText(res, 400, message);
-          return;
-        }
-      }
-
-      if (req.method === "POST" && isInitializeRequestMessage(parsedBody)) {
-        closeIdleSessions(sessions, idleTtlMs);
-        const { server, transport } = await createSession(runtime, sessions, maxSessions);
-        await transport.handleRequest(
-          req as IncomingMessage & { auth?: AuthInfo },
-          res,
-          parsedBody,
-        );
-
-        if (transport.sessionId === undefined) {
-          await transport.close();
-          await server.close();
-        }
-
-        return;
-      }
-
-      const sessionIdHeader = getSingleHeaderValue(req, "mcp-session-id");
-      if (sessionIdHeader === "multiple") {
-        sendJsonRpcError(
-          res,
-          400,
-          -32000,
-          "Bad Request: Mcp-Session-Id header must be a single value",
-        );
-        return;
-      }
-      if (!sessionIdHeader) {
-        sendJsonRpcError(res, 400, -32000, "Bad Request: Mcp-Session-Id header is required");
-        return;
-      }
-
-      const session = sessions.get(sessionIdHeader);
-      if (!session) {
-        sendJsonRpcError(res, 404, -32001, "Session not found");
-        return;
-      }
-
-      session.lastSeenAtMs = Date.now();
-      closeIdleSessions(sessions, idleTtlMs);
-      await session.transport.handleRequest(
-        req as IncomingMessage & { auth?: AuthInfo },
-        res,
-        parsedBody,
-      );
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-
-      console.error(`[ailss-mcp-http] request error: ${message}`);
-      sendText(res, 500, "internal error");
-    }
-  });
+  }
 
   await new Promise<void>((resolve, reject) => {
     const onError = (error: unknown) => reject(error);

--- a/packages/mcp/src/httpServerConfig.ts
+++ b/packages/mcp/src/httpServerConfig.ts
@@ -1,0 +1,86 @@
+import type { AilssMcpRuntime } from "./createAilssMcpServer.js";
+
+export type HttpConfig = {
+  host: string;
+  port: number;
+  path: string;
+  token: string;
+};
+
+export type StartHttpServerOptions = {
+  runtime: AilssMcpRuntime;
+  config: HttpConfig;
+  maxSessions?: number;
+  idleTtlMs?: number;
+  shutdown?: {
+    path?: string;
+    token: string;
+    exitProcess?: boolean;
+  };
+};
+
+export type ShutdownConfig = {
+  path: string;
+  token: string;
+  exitProcess: boolean;
+};
+
+const DEFAULT_SHUTDOWN_PATH = "/__ailss/shutdown";
+
+export function requireLocalhostHost(host: string): void {
+  if (host === "127.0.0.1") return;
+  if (host === "localhost") return;
+  if (host === "::1") return;
+  throw new Error(`Refusing to bind MCP HTTP server to non-localhost host: "${host}"`);
+}
+
+export function parseHttpConfigFromEnv(): HttpConfig {
+  const host = (process.env.AILSS_MCP_HTTP_HOST ?? "127.0.0.1").trim();
+  requireLocalhostHost(host);
+
+  const portRaw = (process.env.AILSS_MCP_HTTP_PORT ?? "31415").trim();
+  const port = Number.parseInt(portRaw, 10);
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid AILSS_MCP_HTTP_PORT: "${portRaw}"`);
+  }
+
+  const pathRaw = (process.env.AILSS_MCP_HTTP_PATH ?? "/mcp").trim() || "/mcp";
+  const path = pathRaw.startsWith("/") ? pathRaw : `/${pathRaw}`;
+
+  const token = (process.env.AILSS_MCP_HTTP_TOKEN ?? process.env.AILSS_MCP_TOKEN ?? "").trim();
+  if (!token) {
+    throw new Error("Missing AILSS_MCP_HTTP_TOKEN. Refusing to start without auth.");
+  }
+
+  return { host, port, path, token };
+}
+
+export function parseMaxSessionsFromEnv(): number {
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "50").trim();
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 1) return 50;
+  return n;
+}
+
+export function parseIdleTtlMsFromEnv(): number {
+  const raw = (process.env.AILSS_MCP_HTTP_IDLE_TTL_MS ?? "3600000").trim();
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return 3_600_000;
+  return n;
+}
+
+export function normalizeShutdownConfig(
+  shutdown: StartHttpServerOptions["shutdown"] | undefined,
+): ShutdownConfig | null {
+  if (!shutdown) return null;
+
+  const token = shutdown.token.trim();
+  if (!token) return null;
+
+  const rawPath = shutdown.path ?? DEFAULT_SHUTDOWN_PATH;
+  return {
+    path: rawPath.startsWith("/") ? rawPath : `/${rawPath}`,
+    token,
+    exitProcess: shutdown.exitProcess ?? false,
+  };
+}

--- a/packages/mcp/src/httpServerRequest.ts
+++ b/packages/mcp/src/httpServerRequest.ts
@@ -1,0 +1,89 @@
+import type { IncomingMessage } from "node:http";
+
+import type { HttpConfig } from "./httpServerConfig.js";
+
+export function baseUrlForRequest(req: IncomingMessage, config: HttpConfig): URL {
+  const reqUrl = req.url ?? "/";
+  return new URL(reqUrl, `http://${config.host}:${config.port}`);
+}
+
+export function extractBearerToken(req: IncomingMessage, url: URL): string | null {
+  const auth = req.headers.authorization;
+  if (typeof auth === "string") {
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m?.[1]) return m[1].trim();
+  }
+
+  const headerToken = req.headers["x-ailss-token"];
+  if (typeof headerToken === "string" && headerToken.trim()) return headerToken.trim();
+
+  const queryToken = url.searchParams.get("token");
+  if (queryToken && queryToken.trim()) return queryToken.trim();
+
+  return null;
+}
+
+export async function readJsonBody(req: IncomingMessage, limitBytes: number): Promise<unknown> {
+  return await new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > limitBytes) {
+        reject(new Error("Request body too large."));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    req.on("end", () => {
+      if (chunks.length === 0) {
+        resolve(undefined);
+        return;
+      }
+
+      const text = Buffer.concat(chunks).toString("utf8").trim();
+      if (!text) {
+        resolve(undefined);
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(text));
+      } catch {
+        reject(new Error("Invalid JSON body."));
+      }
+    });
+
+    req.on("error", (error) => reject(error));
+  });
+}
+
+export function isInitializeRequestMessage(body: unknown): boolean {
+  if (!body) return false;
+  if (Array.isArray(body)) return body.some(isInitializeRequestMessage);
+  if (typeof body !== "object") return false;
+
+  const method = (body as { method?: unknown }).method;
+  return method === "initialize";
+}
+
+export function getSingleHeaderValue(
+  req: IncomingMessage,
+  name: string,
+): string | null | "multiple" {
+  const key = name.toLowerCase();
+
+  const distinct = req.headersDistinct?.[key];
+  if (Array.isArray(distinct)) {
+    if (distinct.length === 1) return distinct[0] ?? null;
+    if (distinct.length > 1) return "multiple";
+  }
+
+  const value = req.headers[key];
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return "multiple";
+  return null;
+}

--- a/packages/mcp/src/httpServerRoutes.ts
+++ b/packages/mcp/src/httpServerRoutes.ts
@@ -1,0 +1,164 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+
+import type { AilssMcpRuntime } from "./createAilssMcpServer.js";
+import type { HttpConfig, ShutdownConfig } from "./httpServerConfig.js";
+import {
+  baseUrlForRequest,
+  extractBearerToken,
+  getSingleHeaderValue,
+  isInitializeRequestMessage,
+  readJsonBody,
+} from "./httpServerRequest.js";
+import { createSession, McpSessionStore } from "./httpServerSessions.js";
+
+type CreateHttpRequestHandlerOptions = {
+  config: HttpConfig;
+  runtime: AilssMcpRuntime;
+  sessionStore: McpSessionStore;
+  shutdown: ShutdownConfig | null;
+  isShuttingDown: () => boolean;
+  startShuttingDown: () => void;
+  close: () => Promise<void>;
+};
+
+function sendText(res: ServerResponse, code: number, message: string): void {
+  res.statusCode = code;
+  res.setHeader("content-type", "text/plain; charset=utf-8");
+  res.end(message);
+}
+
+function sendJsonRpcError(
+  res: ServerResponse,
+  code: number,
+  mcpErrorCode: number,
+  message: string,
+): void {
+  res.statusCode = code;
+  res.setHeader("content-type", "application/json; charset=utf-8");
+  res.end(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: { code: mcpErrorCode, message },
+      id: null,
+    }),
+  );
+}
+
+export function createHttpRequestHandler(options: CreateHttpRequestHandlerOptions) {
+  return async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const url = baseUrlForRequest(req, options.config);
+
+      if (url.pathname === "/health") {
+        sendText(res, 200, "ok");
+        return;
+      }
+
+      if (options.shutdown && url.pathname === options.shutdown.path) {
+        if (req.method !== "POST") {
+          sendText(res, 405, "method not allowed");
+          return;
+        }
+
+        const token = extractBearerToken(req, url);
+        if (token !== options.shutdown.token) {
+          sendText(res, 401, "unauthorized");
+          return;
+        }
+
+        if (options.isShuttingDown()) {
+          sendText(res, 200, "shutting down");
+          return;
+        }
+
+        options.startShuttingDown();
+        sendText(res, 200, "shutting down");
+        setImmediate(() => {
+          void options.close().finally(() => {
+            if (options.shutdown?.exitProcess) process.exit(0);
+          });
+        });
+        return;
+      }
+
+      if (options.isShuttingDown()) {
+        sendText(res, 503, "shutting down");
+        return;
+      }
+
+      if (url.pathname !== options.config.path) {
+        sendText(res, 404, "not found");
+        return;
+      }
+
+      const token = extractBearerToken(req, url);
+      if (token !== options.config.token) {
+        sendText(res, 401, "unauthorized");
+        return;
+      }
+
+      let parsedBody: unknown = undefined;
+      if (req.method === "POST") {
+        try {
+          parsedBody = await readJsonBody(req, 1_000_000);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Bad request.";
+          sendText(res, 400, message);
+          return;
+        }
+      }
+
+      if (req.method === "POST" && isInitializeRequestMessage(parsedBody)) {
+        options.sessionStore.closeIdleSessions();
+        const { server, transport } = await createSession(options.runtime, options.sessionStore);
+        await transport.handleRequest(
+          req as IncomingMessage & { auth?: AuthInfo },
+          res,
+          parsedBody,
+        );
+
+        if (transport.sessionId === undefined) {
+          await transport.close();
+          await server.close();
+        }
+
+        return;
+      }
+
+      const sessionIdHeader = getSingleHeaderValue(req, "mcp-session-id");
+      if (sessionIdHeader === "multiple") {
+        sendJsonRpcError(
+          res,
+          400,
+          -32000,
+          "Bad Request: Mcp-Session-Id header must be a single value",
+        );
+        return;
+      }
+      if (!sessionIdHeader) {
+        sendJsonRpcError(res, 400, -32000, "Bad Request: Mcp-Session-Id header is required");
+        return;
+      }
+
+      const session = options.sessionStore.touchSession(sessionIdHeader);
+      if (!session) {
+        sendJsonRpcError(res, 404, -32001, "Session not found");
+        return;
+      }
+
+      options.sessionStore.closeIdleSessions();
+      await session.transport.handleRequest(
+        req as IncomingMessage & { auth?: AuthInfo },
+        res,
+        parsedBody,
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      console.error(`[ailss-mcp-http] request error: ${message}`);
+      sendText(res, 500, "internal error");
+    }
+  };
+}

--- a/packages/mcp/src/httpServerSessions.ts
+++ b/packages/mcp/src/httpServerSessions.ts
@@ -1,0 +1,109 @@
+import { randomUUID } from "node:crypto";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { createAilssMcpServerFromRuntime, type AilssMcpRuntime } from "./createAilssMcpServer.js";
+
+export type McpSession = {
+  sessionId: string;
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+  createdAtMs: number;
+  lastSeenAtMs: number;
+};
+
+export class McpSessionStore {
+  readonly #sessions = new Map<string, McpSession>();
+  readonly #maxSessions: number;
+  readonly #idleTtlMs: number;
+
+  constructor(maxSessions: number, idleTtlMs: number) {
+    this.#maxSessions = maxSessions;
+    this.#idleTtlMs = idleTtlMs;
+  }
+
+  initializeSession(
+    sessionId: string,
+    server: McpServer,
+    transport: StreamableHTTPServerTransport,
+  ): void {
+    const now = Date.now();
+    this.#sessions.set(sessionId, {
+      sessionId,
+      server,
+      transport,
+      createdAtMs: now,
+      lastSeenAtMs: now,
+    });
+    this.#evictOldestSessions();
+  }
+
+  closeSession(sessionId: string): void {
+    this.#sessions.delete(sessionId);
+  }
+
+  touchSession(sessionId: string): McpSession | undefined {
+    const session = this.#sessions.get(sessionId);
+    if (!session) return undefined;
+    session.lastSeenAtMs = Date.now();
+    return session;
+  }
+
+  closeIdleSessions(): void {
+    if (this.#idleTtlMs <= 0) return;
+    const now = Date.now();
+
+    for (const [sessionId, session] of this.#sessions.entries()) {
+      if (now - session.lastSeenAtMs <= this.#idleTtlMs) continue;
+      this.#sessions.delete(sessionId);
+      session.transport.close().catch(() => {});
+      session.server.close().catch(() => {});
+    }
+  }
+
+  async closeAllSessions(): Promise<void> {
+    const sessionClose = Promise.allSettled(
+      Array.from(this.#sessions.values()).flatMap((session) => [
+        session.transport.close(),
+        session.server.close(),
+      ]),
+    );
+    this.#sessions.clear();
+    await sessionClose;
+  }
+
+  #evictOldestSessions(): void {
+    while (this.#sessions.size > this.#maxSessions) {
+      let oldest: McpSession | null = null;
+      for (const session of this.#sessions.values()) {
+        if (!oldest) oldest = session;
+        else if (session.lastSeenAtMs < oldest.lastSeenAtMs) oldest = session;
+      }
+
+      if (!oldest) return;
+      this.#sessions.delete(oldest.sessionId);
+      oldest.transport.close().catch(() => {});
+      oldest.server.close().catch(() => {});
+    }
+  }
+}
+
+export async function createSession(
+  runtime: AilssMcpRuntime,
+  sessionStore: McpSessionStore,
+): Promise<{ server: McpServer; transport: StreamableHTTPServerTransport }> {
+  const { server } = createAilssMcpServerFromRuntime(runtime);
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: () => randomUUID(),
+    onsessioninitialized: (sessionId) => {
+      sessionStore.initializeSession(sessionId, server, transport);
+    },
+    onsessionclosed: (sessionId) => {
+      sessionStore.closeSession(sessionId);
+    },
+  });
+
+  await server.connect(transport);
+  return { server, transport };
+}

--- a/packages/mcp/test/httpServerConfig.unit.test.ts
+++ b/packages/mcp/test/httpServerConfig.unit.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  normalizeShutdownConfig,
+  parseHttpConfigFromEnv,
+  parseIdleTtlMsFromEnv,
+  parseMaxSessionsFromEnv,
+  requireLocalhostHost,
+} from "../src/httpServerConfig.js";
+
+type HttpEnvKey =
+  | "AILSS_MCP_HTTP_HOST"
+  | "AILSS_MCP_HTTP_PORT"
+  | "AILSS_MCP_HTTP_PATH"
+  | "AILSS_MCP_HTTP_TOKEN"
+  | "AILSS_MCP_TOKEN"
+  | "AILSS_MCP_HTTP_MAX_SESSIONS"
+  | "AILSS_MCP_HTTP_IDLE_TTL_MS";
+
+const HTTP_ENV_KEYS: HttpEnvKey[] = [
+  "AILSS_MCP_HTTP_HOST",
+  "AILSS_MCP_HTTP_PORT",
+  "AILSS_MCP_HTTP_PATH",
+  "AILSS_MCP_HTTP_TOKEN",
+  "AILSS_MCP_TOKEN",
+  "AILSS_MCP_HTTP_MAX_SESSIONS",
+  "AILSS_MCP_HTTP_IDLE_TTL_MS",
+];
+
+const originalEnv: Partial<Record<HttpEnvKey, string | undefined>> = {};
+for (const key of HTTP_ENV_KEYS) {
+  originalEnv[key] = process.env[key];
+}
+
+afterEach(() => {
+  for (const key of HTTP_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+describe("httpServerConfig helpers", () => {
+  it("accepts localhost hosts and rejects non-localhost hosts", () => {
+    expect(() => requireLocalhostHost("127.0.0.1")).not.toThrow();
+    expect(() => requireLocalhostHost("localhost")).not.toThrow();
+    expect(() => requireLocalhostHost("::1")).not.toThrow();
+    expect(() => requireLocalhostHost("0.0.0.0")).toThrow(
+      'Refusing to bind MCP HTTP server to non-localhost host: "0.0.0.0"',
+    );
+  });
+
+  it("parses env config with defaults", () => {
+    delete process.env.AILSS_MCP_HTTP_HOST;
+    delete process.env.AILSS_MCP_HTTP_PORT;
+    delete process.env.AILSS_MCP_HTTP_PATH;
+    process.env.AILSS_MCP_HTTP_TOKEN = "token-a";
+    delete process.env.AILSS_MCP_TOKEN;
+
+    expect(parseHttpConfigFromEnv()).toEqual({
+      host: "127.0.0.1",
+      port: 31415,
+      path: "/mcp",
+      token: "token-a",
+    });
+  });
+
+  it("normalizes path and falls back to AILSS_MCP_TOKEN", () => {
+    process.env.AILSS_MCP_HTTP_HOST = "localhost";
+    process.env.AILSS_MCP_HTTP_PORT = "8080";
+    process.env.AILSS_MCP_HTTP_PATH = "custom";
+    delete process.env.AILSS_MCP_HTTP_TOKEN;
+    process.env.AILSS_MCP_TOKEN = "fallback-token";
+
+    expect(parseHttpConfigFromEnv()).toEqual({
+      host: "localhost",
+      port: 8080,
+      path: "/custom",
+      token: "fallback-token",
+    });
+  });
+
+  it("throws on invalid port and missing token", () => {
+    process.env.AILSS_MCP_HTTP_HOST = "127.0.0.1";
+    process.env.AILSS_MCP_HTTP_PORT = "70000";
+    process.env.AILSS_MCP_HTTP_TOKEN = "token";
+    expect(() => parseHttpConfigFromEnv()).toThrow('Invalid AILSS_MCP_HTTP_PORT: "70000"');
+
+    process.env.AILSS_MCP_HTTP_PORT = "31415";
+    process.env.AILSS_MCP_HTTP_TOKEN = "";
+    process.env.AILSS_MCP_TOKEN = "";
+    expect(() => parseHttpConfigFromEnv()).toThrow(
+      "Missing AILSS_MCP_HTTP_TOKEN. Refusing to start without auth.",
+    );
+  });
+
+  it("parses max sessions and idle ttl with safe defaults", () => {
+    delete process.env.AILSS_MCP_HTTP_MAX_SESSIONS;
+    delete process.env.AILSS_MCP_HTTP_IDLE_TTL_MS;
+    expect(parseMaxSessionsFromEnv()).toBe(50);
+    expect(parseIdleTtlMsFromEnv()).toBe(3_600_000);
+
+    process.env.AILSS_MCP_HTTP_MAX_SESSIONS = "abc";
+    process.env.AILSS_MCP_HTTP_IDLE_TTL_MS = "-1";
+    expect(parseMaxSessionsFromEnv()).toBe(50);
+    expect(parseIdleTtlMsFromEnv()).toBe(3_600_000);
+
+    process.env.AILSS_MCP_HTTP_MAX_SESSIONS = "12";
+    process.env.AILSS_MCP_HTTP_IDLE_TTL_MS = "2500";
+    expect(parseMaxSessionsFromEnv()).toBe(12);
+    expect(parseIdleTtlMsFromEnv()).toBe(2500);
+  });
+
+  it("normalizes shutdown config", () => {
+    expect(normalizeShutdownConfig(undefined)).toBeNull();
+    expect(normalizeShutdownConfig({ token: "   " })).toBeNull();
+    expect(normalizeShutdownConfig({ token: "x" })).toEqual({
+      path: "/__ailss/shutdown",
+      token: "x",
+      exitProcess: false,
+    });
+    expect(normalizeShutdownConfig({ path: "bye", token: " t ", exitProcess: true })).toEqual({
+      path: "/bye",
+      token: "t",
+      exitProcess: true,
+    });
+  });
+});

--- a/packages/mcp/test/httpServerRequest.unit.test.ts
+++ b/packages/mcp/test/httpServerRequest.unit.test.ts
@@ -19,8 +19,10 @@ function createRequest(options?: {
   const req = new PassThrough() as IncomingMessage & PassThrough;
   req.url = options?.url ?? "/";
   req.headers = options?.headers ?? {};
-  (req as IncomingMessage & { headersDistinct?: Record<string, string[]> }).headersDistinct =
-    options?.headersDistinct;
+  if (options?.headersDistinct) {
+    (req as IncomingMessage & { headersDistinct: Record<string, string[]> }).headersDistinct =
+      options.headersDistinct;
+  }
   return req;
 }
 

--- a/packages/mcp/test/httpServerRequest.unit.test.ts
+++ b/packages/mcp/test/httpServerRequest.unit.test.ts
@@ -1,0 +1,141 @@
+import { PassThrough } from "node:stream";
+import type { IncomingMessage } from "node:http";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  baseUrlForRequest,
+  extractBearerToken,
+  getSingleHeaderValue,
+  isInitializeRequestMessage,
+  readJsonBody,
+} from "../src/httpServerRequest.js";
+
+function createRequest(options?: {
+  url?: string;
+  headers?: Record<string, string | string[] | undefined>;
+  headersDistinct?: Record<string, string[]>;
+}): IncomingMessage & PassThrough {
+  const req = new PassThrough() as IncomingMessage & PassThrough;
+  req.url = options?.url ?? "/";
+  req.headers = options?.headers ?? {};
+  (req as IncomingMessage & { headersDistinct?: Record<string, string[]> }).headersDistinct =
+    options?.headersDistinct;
+  return req;
+}
+
+describe("httpServerRequest helpers", () => {
+  it("builds base URL from request URL and config", () => {
+    const req = createRequest({ url: "/mcp?x=1" });
+    const url = baseUrlForRequest(req, {
+      host: "127.0.0.1",
+      port: 31415,
+      path: "/mcp",
+      token: "t",
+    });
+    expect(url.toString()).toBe("http://127.0.0.1:31415/mcp?x=1");
+  });
+
+  it("extracts bearer token in priority order", () => {
+    const fromAuth = extractBearerToken(
+      createRequest({
+        headers: {
+          authorization: "Bearer auth-token  ",
+          "x-ailss-token": "header-token",
+        },
+      }),
+      new URL("http://127.0.0.1:31415/mcp?token=query-token"),
+    );
+    expect(fromAuth).toBe("auth-token");
+
+    const fromHeader = extractBearerToken(
+      createRequest({
+        headers: { "x-ailss-token": "header-token" },
+      }),
+      new URL("http://127.0.0.1:31415/mcp?token=query-token"),
+    );
+    expect(fromHeader).toBe("header-token");
+
+    const fromQuery = extractBearerToken(
+      createRequest({
+        headers: {},
+      }),
+      new URL("http://127.0.0.1:31415/mcp?token=query-token"),
+    );
+    expect(fromQuery).toBe("query-token");
+
+    const missing = extractBearerToken(
+      createRequest({
+        headers: {},
+      }),
+      new URL("http://127.0.0.1:31415/mcp"),
+    );
+    expect(missing).toBeNull();
+  });
+
+  it("parses json request body and handles empty/invalid/oversized payloads", async () => {
+    const reqOk = createRequest();
+    const bodyOkPromise = readJsonBody(reqOk, 10_000);
+    reqOk.end(JSON.stringify({ method: "initialize" }));
+    await expect(bodyOkPromise).resolves.toEqual({ method: "initialize" });
+
+    const reqEmpty = createRequest();
+    const bodyEmptyPromise = readJsonBody(reqEmpty, 10_000);
+    reqEmpty.end("");
+    await expect(bodyEmptyPromise).resolves.toBeUndefined();
+
+    const reqInvalid = createRequest();
+    const bodyInvalidPromise = readJsonBody(reqInvalid, 10_000);
+    reqInvalid.end("{invalid");
+    await expect(bodyInvalidPromise).rejects.toThrow("Invalid JSON body.");
+
+    const reqTooLarge = createRequest();
+    const bodyTooLargePromise = readJsonBody(reqTooLarge, 2);
+    reqTooLarge.end("123");
+    await expect(bodyTooLargePromise).rejects.toThrow("Request body too large.");
+  });
+
+  it("detects initialize requests from single and batch payloads", () => {
+    expect(isInitializeRequestMessage({ method: "initialize" })).toBe(true);
+    expect(isInitializeRequestMessage([{ method: "foo" }, { method: "initialize" }])).toBe(true);
+    expect(isInitializeRequestMessage({ method: "tools/list" })).toBe(false);
+    expect(isInitializeRequestMessage(undefined)).toBe(false);
+  });
+
+  it("reads single header value and rejects duplicates", () => {
+    const singleDistinct = getSingleHeaderValue(
+      createRequest({
+        headersDistinct: { "mcp-session-id": ["s1"] },
+      }),
+      "mcp-session-id",
+    );
+    expect(singleDistinct).toBe("s1");
+
+    const multipleDistinct = getSingleHeaderValue(
+      createRequest({
+        headersDistinct: { "mcp-session-id": ["s1", "s2"] },
+      }),
+      "mcp-session-id",
+    );
+    expect(multipleDistinct).toBe("multiple");
+
+    const singleHeader = getSingleHeaderValue(
+      createRequest({
+        headers: { "mcp-session-id": "s1" },
+      }),
+      "mcp-session-id",
+    );
+    expect(singleHeader).toBe("s1");
+
+    const multipleHeader = getSingleHeaderValue(
+      createRequest({
+        headers: { "mcp-session-id": ["s1", "s2"] },
+      }),
+      "mcp-session-id",
+    );
+    expect(multipleHeader).toBe("multiple");
+
+    const none = getSingleHeaderValue(createRequest(), "mcp-session-id");
+    expect(none).toBeNull();
+  });
+});

--- a/packages/mcp/test/httpServerSessions.unit.test.ts
+++ b/packages/mcp/test/httpServerSessions.unit.test.ts
@@ -1,0 +1,89 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { McpSessionStore } from "../src/httpServerSessions.js";
+
+function createSessionMocks() {
+  const transportClose = vi.fn(async () => {});
+  const serverClose = vi.fn(async () => {});
+
+  return {
+    server: { close: serverClose } as unknown as McpServer,
+    transport: { close: transportClose } as unknown as StreamableHTTPServerTransport,
+    transportClose,
+    serverClose,
+  };
+}
+
+describe("McpSessionStore", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("evicts the oldest session when max session cap is exceeded", () => {
+    const store = new McpSessionStore(1, 60_000);
+    const first = createSessionMocks();
+    const second = createSessionMocks();
+
+    store.initializeSession("session-1", first.server, first.transport);
+    store.initializeSession("session-2", second.server, second.transport);
+
+    expect(store.touchSession("session-1")).toBeUndefined();
+    expect(store.touchSession("session-2")).toBeTruthy();
+    expect(first.transportClose).toHaveBeenCalledTimes(1);
+    expect(first.serverClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes sessions that exceed idle ttl", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const store = new McpSessionStore(10, 1_000);
+    const active = createSessionMocks();
+
+    store.initializeSession("session-idle", active.server, active.transport);
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.500Z"));
+    store.closeIdleSessions();
+    expect(store.touchSession("session-idle")).toBeTruthy();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:02.000Z"));
+    store.closeIdleSessions();
+    expect(store.touchSession("session-idle")).toBeUndefined();
+    expect(active.transportClose).toHaveBeenCalledTimes(1);
+    expect(active.serverClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close idle sessions when idle ttl is disabled", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    const store = new McpSessionStore(10, 0);
+    const active = createSessionMocks();
+
+    store.initializeSession("session-active", active.server, active.transport);
+    vi.setSystemTime(new Date("2026-01-01T00:10:00.000Z"));
+    store.closeIdleSessions();
+
+    expect(store.touchSession("session-active")).toBeTruthy();
+    expect(active.transportClose).not.toHaveBeenCalled();
+    expect(active.serverClose).not.toHaveBeenCalled();
+  });
+
+  it("closes and clears all sessions", async () => {
+    const store = new McpSessionStore(10, 60_000);
+    const one = createSessionMocks();
+    const two = createSessionMocks();
+
+    store.initializeSession("session-1", one.server, one.transport);
+    store.initializeSession("session-2", two.server, two.transport);
+    await store.closeAllSessions();
+
+    expect(store.touchSession("session-1")).toBeUndefined();
+    expect(store.touchSession("session-2")).toBeUndefined();
+    expect(one.transportClose).toHaveBeenCalledTimes(1);
+    expect(one.serverClose).toHaveBeenCalledTimes(1);
+    expect(two.transportClose).toHaveBeenCalledTimes(1);
+    expect(two.serverClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What

- Split MCP HTTP server concerns into focused modules for config/env parsing, request/auth parsing, session lifecycle storage, and route handling.
- Preserved public API signatures for `startAilssMcpHttpServer` and `startAilssMcpHttpServerFromEnv`.
- Kept HTTP contract, authentication behavior, initialize/session flow, and shutdown semantics unchanged.

## Why

- Reduce coupling inside `packages/mcp/src/httpServer.ts` to lower regression risk during future server changes.
- Align implementation with the refactor scope requested in issue #82.

- Fixes #82

## How

- Added `httpServerConfig.ts`, `httpServerRequest.ts`, `httpServerSessions.ts`, and `httpServerRoutes.ts` under `packages/mcp/src`.
- Kept server startup/listen/close orchestration in `httpServer.ts` and wired extracted route handling into it.
- Validation:
  - `pnpm --filter @ailss/mcp typecheck`
  - `pnpm --filter @ailss/mcp build`
  - `pnpm test`
