### PR TITLE
docs: add test issue template and agents mapping

### DIFF
--- a/.github/ISSUE_TEMPLATE/test.md
+++ b/.github/ISSUE_TEMPLATE/test.md
@@ -1,0 +1,53 @@
+---
+name: Test improvement (Markdown)
+about: Add or improve tests without changing user-visible behavior (Markdown template)
+title: "test: "
+labels: ["test"]
+---
+
+Use this template for test-only improvements and regression coverage.
+Please avoid adding component/scope to the title (no `test(mcp): ...`, no `plugin: ...`).
+Use labels for component tagging instead.
+
+## Component
+
+Which area should be covered?
+
+- [ ] Indexer (`packages/indexer`)
+- [ ] MCP server (`packages/mcp`)
+- [ ] Obsidian plugin (`packages/obsidian-plugin`)
+- [ ] Core/shared (`packages/core`)
+- [ ] Docs
+- [ ] Ops/CI
+- [ ] Multiple components
+
+## Problem statement
+
+What gap in test coverage or regression risk are you addressing?
+
+## Test goal
+
+What should become verifiable after this issue is done?
+
+## In scope
+
+What tests and files are included?
+
+## Out of scope
+
+What must stay unchanged? (for example: no runtime behavior change)
+
+## Test strategy
+
+- [ ] Unit tests
+- [ ] Integration tests
+- [ ] End-to-end tests
+- [ ] Golden/snapshot contract tests
+
+## Validation
+
+Which checks/tests should pass?
+
+## Done criteria
+
+What defines completion?

--- a/.github/ISSUE_TEMPLATE/test.yml
+++ b/.github/ISSUE_TEMPLATE/test.yml
@@ -1,0 +1,91 @@
+name: Test improvement
+description: Add or improve tests without changing user-visible behavior
+title: "test: "
+labels: ["test"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for test-only improvements and regression coverage.
+        Please avoid adding component/scope to the title (no `test(mcp): ...`, no `plugin: ...`).
+        Use labels for component tagging instead.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which area should be covered?
+      options:
+        - Indexer (packages/indexer)
+        - MCP server (packages/mcp)
+        - Obsidian plugin (packages/obsidian-plugin)
+        - Core/shared (packages/core)
+        - Docs
+        - Ops/CI
+        - Multiple components
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What gap in test coverage or regression risk are you addressing?
+      placeholder: "A startup helper branch is not directly covered and regressions are hard to pinpoint."
+    validations:
+      required: true
+
+  - type: textarea
+    id: goal
+    attributes:
+      label: Test goal
+      description: What should become verifiable after this issue is done?
+      placeholder: "Directly cover helper-level branches with deterministic unit tests."
+    validations:
+      required: true
+
+  - type: textarea
+    id: in_scope
+    attributes:
+      label: In scope
+      description: What tests and files are included?
+      placeholder: "- Add unit tests for X\n- Add minimal test seam if required"
+    validations:
+      required: true
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What must stay unchanged?
+      placeholder: "- No runtime behavior change\n- No new configuration options"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: strategy
+    attributes:
+      label: Test strategy
+      options:
+        - label: Unit tests
+        - label: Integration tests
+        - label: End-to-end tests
+        - label: Golden/snapshot contract tests
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Which checks/tests should pass?
+      placeholder: "- pnpm --filter ailss-obsidian typecheck\n- pnpm test"
+    validations:
+      required: true
+
+  - type: textarea
+    id: done_criteria
+    attributes:
+      label: Done criteria
+      description: What defines completion?
+      placeholder: "- Target branches are covered directly\n- Existing behavior remains unchanged\n- Validation checks pass"
+    validations:
+      required: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,7 @@ When filing an issue, optimize for fast, high-confidence triage.
   - `docs` template → `docs: ...` title + `docs` label
   - `question` template → `question: ...` title + `question` label
   - `refactor` template → `refactor: ...` title + `refactor` label (do not combine with `enhancement`)
+  - `test` template → `test: ...` title + `test` label
 - Avoid encoding component or scope in the title (no `type(scope): ...` and no `component: ...` prefixes); use labels (and template fields when present) instead.
 - Problem statement: what you were trying to do and why.
 - Reproduction: numbered steps starting from a clean state; include minimal config/snippets when possible.


### PR DESCRIPTION
## What

- Add a new `test` issue template pair under `.github/ISSUE_TEMPLATE`.
- Add template mapping guidance in `AGENTS.md` for `test: ...` + `test` label.
- Standardize required fields for test-only work (scope, validation, done criteria).

## Why

- Test-focused tasks currently fall between `refactor` and `feature` templates.
- A dedicated template improves triage quality and keeps test-only work explicit.
- Align issue intake with Conventional title/label conventions.

## How

- Add `.github/ISSUE_TEMPLATE/test.yml` (Issue Form).
- Add `.github/ISSUE_TEMPLATE/test.md` (Markdown fallback).
- Update `AGENTS.md` issue template mapping with `test` entry.
- Validation: pre-push `pnpm check` (format/lint/typecheck/test) passed.
