### PR TITLE
feat: add typed-link relation diagnostics and canonical filtering

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -45,6 +45,7 @@ Read-first tools (implemented in this repo):
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `list_typed_link_rels`: list typed-link relation keys (`rel`) with usage counts and canonical/non-canonical classification
 
 Client guidance (Codex):
 
@@ -67,6 +68,7 @@ Frontmatter query support (current):
 - The MCP surface supports both:
   - semantic retrieval via `get_context`
   - metadata filtering via `search_notes` + typed-link navigation/backrefs via `expand_typed_links_outgoing` / `find_typed_links_incoming`
+  - typed-link relation diagnostics via `list_typed_link_rels`
 
 Read-first tools (planned):
 

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,7 +24,7 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-- Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+- Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`, `list_typed_link_rels`
 - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `canonicalize_typed_links`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
@@ -131,11 +131,13 @@ Implemented:
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `list_typed_link_rels`: list typed-link relation keys (`rel`) with usage counts and canonical/non-canonical classification
 
 Notes on queryability (current):
 
 - AILSS stores normalized frontmatter + typed links in SQLite (used for graph expansion and retrieval).
 - The MCP surface supports both semantic retrieval (`get_context`) and structured navigation/filtering (`expand_typed_links_outgoing`, `find_typed_links_incoming`, `search_notes`).
+- Relation-level diagnostics are available via `list_typed_link_rels` (for legacy/non-canonical rel visibility).
 - Frontmatter normalization coerces YAML-inferred scalars (unquoted numbers/dates) to strings for core identity fields (`id`, `created`, `updated`) so existing vault notes can remain unquoted.
 
 Planned:

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -14,6 +14,7 @@ mcp_tools:
   - search_notes
   - list_tags
   - list_keywords
+  - list_typed_link_rels
   # Only when write tools are enabled (AILSS_ENABLE_WRITE_TOOLS=1)
   - capture_note
   - canonicalize_typed_links
@@ -66,6 +67,7 @@ Treat the Obsidian vault as the Single Source of Truth (SSOT): always ground cla
   - `path_prefix` limits only the source-note scan set; typed-link target resolution for diagnostics is vault-wide.
 - Use `find_broken_links` when you need to detect unresolved wikilinks/typed links after moves/renames.
 - Use `find_typed_links_incoming` when you need incoming edges/backrefs for a target.
+- Use `list_typed_link_rels` when you need relation-level diagnostics (for example, legacy/non-canonical rels such as `links_to`).
 
 ### Safe edits (explicit apply only)
 

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -50,6 +50,15 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
   - `rel` (string, optional; e.g. `part_of`, `cites`)
   - `to_target` (string, optional; normalized wikilink target)
   - `limit` (int, default: `100`, range: `1–1000`)
+  - `canonical_only` (boolean, default: `true`) — when true, restricts results to canonical typed-link keys only
+
+### `list_typed_link_rels`
+
+- Purpose: list typed-link relation keys (`rel`) with usage counts and canonical/non-canonical classification (DB-only).
+- Input:
+  - `path_prefix` (string, optional)
+  - `limit` (int, default: `200`, range: `1–5000`)
+  - `order_by` (`"count_desc" | "rel_asc"`, default: `"count_desc"`)
 
 ### `read_note`
 

--- a/docs/standards/vault/assistant-workflow.md
+++ b/docs/standards/vault/assistant-workflow.md
@@ -46,8 +46,9 @@ Global working rules for the AILSS Obsidian vault.
 - `search_notes`: DB-backed metadata filtering (frontmatter-derived fields, tags/keywords/sources); no embeddings calls.
 - `list_tags`: list indexed tags and counts (use to reuse existing vocabulary).
 - `list_keywords`: list indexed keywords and counts (use to reuse existing vocabulary).
+- `list_typed_link_rels`: list typed-link relation keys (`rel`) with usage counts and canonical/non-canonical classification.
 - `expand_typed_links_outgoing`: expands outgoing typed links into a bounded graph (metadata only).
-- `find_typed_links_incoming`: find notes that link _to_ a target via typed links (incoming edges).
+- `find_typed_links_incoming`: find notes that link _to_ a target via typed links (incoming edges; `canonical_only=true` by default).
 - `get_vault_tree`: returns a folder/file tree for vault Markdown files.
 - `frontmatter_validate`: validates vault-wide frontmatter key presence + `id`/`created` consistency, and can also emit typed-link ontology diagnostics (`typed_link_constraint_mode`: `off`/`warn`/`error`).
   - `path_prefix` limits the source-note scan set, but typed-link target resolution for diagnostics still uses vault-wide metadata.

--- a/packages/core/src/db/queries/typed-links.ts
+++ b/packages/core/src/db/queries/typed-links.ts
@@ -37,6 +37,7 @@ export function replaceTypedLinks(db: AilssDb, fromPath: string, links: TypedLin
 
 export type TypedLinkQuery = {
   rel?: string;
+  rels?: string[];
   toTarget?: string;
   limit?: number;
 };
@@ -63,6 +64,14 @@ export function findNotesByTypedLink(db: AilssDb, query: TypedLinkQuery): TypedL
     params.push(query.toTarget);
   }
 
+  if (query.rels && query.rels.length > 0) {
+    const rels = query.rels.map((r) => r.trim()).filter(Boolean);
+    if (rels.length > 0) {
+      where.push(`tl.rel IN (${rels.map(() => "?").join(", ")})`);
+      params.push(...rels);
+    }
+  }
+
   const limit = Math.min(Math.max(1, query.limit ?? 100), 1000);
 
   const sql = `
@@ -80,6 +89,46 @@ export function findNotesByTypedLink(db: AilssDb, query: TypedLinkQuery): TypedL
   `;
 
   return db.prepare(sql).all(...params, limit) as TypedLinkBackref[];
+}
+
+export type TypedLinkRelFacet = {
+  rel: string;
+  count: number;
+};
+
+export type TypedLinkRelFacetQuery = {
+  pathPrefix?: string;
+  limit?: number;
+  orderBy?: "count_desc" | "rel_asc";
+};
+
+export function listTypedLinkRels(
+  db: AilssDb,
+  query: TypedLinkRelFacetQuery = {},
+): TypedLinkRelFacet[] {
+  const where: string[] = [];
+  const params: unknown[] = [];
+
+  const pathPrefix = query.pathPrefix?.trim();
+  if (pathPrefix) {
+    where.push(`from_path LIKE ?`);
+    params.push(`${pathPrefix}%`);
+  }
+
+  const limit = Math.min(Math.max(1, query.limit ?? 200), 5000);
+  const orderByClause =
+    query.orderBy === "rel_asc" ? "ORDER BY rel ASC, count DESC" : "ORDER BY count DESC, rel ASC";
+
+  const sql = `
+    SELECT rel, COUNT(*) AS count
+    FROM typed_links
+    ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+    GROUP BY rel
+    ${orderByClause}
+    LIMIT ?
+  `;
+
+  return db.prepare(sql).all(...params, limit) as TypedLinkRelFacet[];
 }
 
 export type ResolvedNoteTarget = {

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -19,6 +19,7 @@ import { registerGetVaultTreeTool } from "./tools/getVaultTree.js";
 import { registerImproveFrontmatterTool } from "./tools/improveFrontmatter.js";
 import { registerListKeywordsTool } from "./tools/listKeywords.js";
 import { registerListTagsTool } from "./tools/listTags.js";
+import { registerListTypedLinkRelsTool } from "./tools/listTypedLinkRels.js";
 import { registerRelocateNoteTool } from "./tools/relocateNote.js";
 import { registerResolveNoteTool } from "./tools/resolveNote.js";
 import { registerSearchNotesTool } from "./tools/searchNotes.js";
@@ -79,6 +80,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   registerSearchNotesTool(server, deps);
   registerListTagsTool(server, deps);
   registerListKeywordsTool(server, deps);
+  registerListTypedLinkRelsTool(server, deps);
   registerFindTypedLinksIncomingTool(server, deps);
 
   if (runtime.enableWriteTools) {

--- a/packages/mcp/src/tools/findTypedLinksIncoming.ts
+++ b/packages/mcp/src/tools/findTypedLinksIncoming.ts
@@ -1,7 +1,7 @@
 // find_typed_links_incoming tool
 // - DB-backed typed-link backref queries (incoming edges)
 
-import { findNotesByTypedLink } from "@ailss/core";
+import { AILSS_TYPED_LINK_KEYS, findNotesByTypedLink } from "@ailss/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
@@ -28,12 +28,19 @@ export function registerFindTypedLinksIncomingTool(server: McpServer, deps: McpT
           .max(1000)
           .default(100)
           .describe("Maximum number of backrefs returned (1–1000)"),
+        canonical_only: z
+          .boolean()
+          .default(true)
+          .describe(
+            "When true, restrict results to canonical frontmatter typed-link keys only (filters out legacy/non-canonical relations).",
+          ),
       },
       outputSchema: z.object({
         query: z.object({
           rel: z.string().nullable(),
           to_target: z.string().nullable(),
           limit: z.number().int(),
+          canonical_only: z.boolean(),
         }),
         backrefs: z.array(
           z.object({
@@ -48,13 +55,19 @@ export function registerFindTypedLinksIncomingTool(server: McpServer, deps: McpT
     },
     async (args) => {
       const query: Parameters<typeof findNotesByTypedLink>[1] = { limit: args.limit };
+      if (args.canonical_only) query.rels = [...AILSS_TYPED_LINK_KEYS];
       if (args.rel) query.rel = args.rel;
       if (args.to_target) query.toTarget = args.to_target;
 
       const backrefs = findNotesByTypedLink(deps.db, query);
 
       const payload = {
-        query: { rel: args.rel ?? null, to_target: args.to_target ?? null, limit: args.limit },
+        query: {
+          rel: args.rel ?? null,
+          to_target: args.to_target ?? null,
+          limit: args.limit,
+          canonical_only: args.canonical_only,
+        },
         backrefs: backrefs.map((b) => ({
           from_path: b.fromPath,
           from_title: b.fromTitle,

--- a/packages/mcp/src/tools/listTypedLinkRels.ts
+++ b/packages/mcp/src/tools/listTypedLinkRels.ts
@@ -1,0 +1,79 @@
+// list_typed_link_rels tool
+// - DB-backed typed-link relation facet listing
+
+import { AILSS_TYPED_LINK_KEYS, listTypedLinkRels } from "@ailss/core";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+
+const ORDER_BY_OPTIONS = ["count_desc", "rel_asc"] as const;
+
+export function registerListTypedLinkRelsTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "list_typed_link_rels",
+    {
+      title: "List typed-link relations",
+      description:
+        "Lists typed-link relation keys (`rel`) with usage counts from the local SQLite DB, including canonical/non-canonical classification.",
+      inputSchema: {
+        path_prefix: z
+          .string()
+          .min(1)
+          .optional()
+          .describe("Only count links from notes under this vault-relative path prefix"),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(5000)
+          .default(200)
+          .describe("Maximum number of relation rows returned (1–5000)"),
+        order_by: z
+          .enum(ORDER_BY_OPTIONS)
+          .default("count_desc")
+          .describe("Sort order: count_desc (default) or rel_asc"),
+      },
+      outputSchema: z.object({
+        query: z.object({
+          path_prefix: z.string().nullable(),
+          limit: z.number().int(),
+          order_by: z.enum(ORDER_BY_OPTIONS),
+        }),
+        rels: z.array(
+          z.object({
+            rel: z.string(),
+            count: z.number().int().nonnegative(),
+            canonical: z.boolean(),
+          }),
+        ),
+      }),
+    },
+    async (args) => {
+      const canonicalRels = new Set<string>(AILSS_TYPED_LINK_KEYS);
+      const rows = listTypedLinkRels(deps.db, {
+        ...(args.path_prefix ? { pathPrefix: args.path_prefix } : {}),
+        limit: args.limit,
+        orderBy: args.order_by,
+      });
+
+      const payload = {
+        query: {
+          path_prefix: args.path_prefix ?? null,
+          limit: args.limit,
+          order_by: args.order_by,
+        },
+        rels: rows.map((row) => ({
+          rel: row.rel,
+          count: row.count,
+          canonical: canonicalRels.has(row.rel),
+        })),
+      };
+
+      return {
+        structuredContent: payload,
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp/test/httpTools.listTypedLinkRels.test.ts
+++ b/packages/mcp/test/httpTools.listTypedLinkRels.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import path from "node:path";
+
+import {
+  assertArray,
+  assertRecord,
+  getStructuredContent,
+  mcpInitialize,
+  mcpToolsCall,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+describe("MCP HTTP server (list_typed_link_rels)", () => {
+  it("lists rel counts and canonical classification", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer(
+        { dbPath, enableWriteTools: false },
+        async ({ url, token, runtime }) => {
+          const now = new Date().toISOString().slice(0, 19);
+
+          const fileStmt = runtime.deps.db.prepare(
+            "INSERT INTO files(path, mtime_ms, size_bytes, sha256, updated_at) VALUES (?, ?, ?, ?, ?)",
+          );
+          const noteStmt = runtime.deps.db.prepare(
+            "INSERT INTO notes(path, note_id, created, title, summary, entity, layer, status, updated, frontmatter_json, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          );
+          const linkStmt = runtime.deps.db.prepare(
+            "INSERT INTO typed_links(from_path, rel, to_target, to_wikilink, position, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+          );
+
+          fileStmt.run("A.md", 0, 0, "0", now);
+          fileStmt.run("B.md", 0, 0, "0", now);
+
+          noteStmt.run(
+            "A.md",
+            "A",
+            now,
+            "A",
+            null,
+            null,
+            "conceptual",
+            "draft",
+            now,
+            JSON.stringify({ id: "A", title: "A", tags: [] }),
+            now,
+          );
+          noteStmt.run(
+            "B.md",
+            "B",
+            now,
+            "B",
+            null,
+            null,
+            "conceptual",
+            "draft",
+            now,
+            JSON.stringify({ id: "B", title: "B", tags: [] }),
+            now,
+          );
+
+          linkStmt.run("A.md", "part_of", "WorldAce", "[[WorldAce]]", 0, now);
+          linkStmt.run("A.md", "links_to", "Legacy Hub", "[[Legacy Hub]]", 1, now);
+          linkStmt.run("B.md", "part_of", "WorldAce", "[[WorldAce]]", 0, now);
+
+          const sessionId = await mcpInitialize(url, token, "client-a");
+          const res = await mcpToolsCall(url, token, sessionId, "list_typed_link_rels", {
+            limit: 10,
+            order_by: "count_desc",
+          });
+
+          const structured = getStructuredContent(res);
+          const query = structured["query"];
+          assertRecord(query, "query");
+          expect(query["path_prefix"]).toBeNull();
+          expect(query["order_by"]).toBe("count_desc");
+
+          const rels = structured["rels"];
+          assertArray(rels, "rels");
+          expect(rels).toHaveLength(2);
+          assertRecord(rels[0], "rels[0]");
+          assertRecord(rels[1], "rels[1]");
+          expect(rels[0]["rel"]).toBe("part_of");
+          expect(rels[0]["count"]).toBe(2);
+          expect(rels[0]["canonical"]).toBe(true);
+          expect(rels[1]["rel"]).toBe("links_to");
+          expect(rels[1]["count"]).toBe(1);
+          expect(rels[1]["canonical"]).toBe(false);
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

- add typed-link relation facet querying in core (`listTypedLinkRels`) and rel-set filtering support in backref queries (`findNotesByTypedLink.rels`)
- add new read MCP tool `list_typed_link_rels` to expose relation counts with canonical/non-canonical classification
- add `canonical_only` (default `true`) to `find_typed_links_incoming` to avoid treating legacy rels as supported ontology keys
- add/extend tests for core query behavior and MCP HTTP tool behavior
- update overview/reference/workflow docs to include the new tool and default canonical filtering behavior

## Why

- distinguish "what exists in DB" from "what is canonically supported" without manual SQL inspection
- reduce false conclusions that legacy rels (for example `links_to`) are currently supported typed-link keys
- improve operator visibility for typed-link hygiene and migration diagnostics
- Fixes #78

## How

- implement grouped `typed_links` relation counting with `pathPrefix`, `limit`, and `orderBy` in `packages/core/src/db/queries/typed-links.ts`
- register `list_typed_link_rels` in MCP server startup and return per-rel counts plus canonical classification (`AILSS_TYPED_LINK_KEYS`)
- apply canonical rel filtering by default in `find_typed_links_incoming` while keeping opt-out via `canonical_only=false`
- validate with repository checks (pre-push): `pnpm format:check && pnpm lint && pnpm typecheck && pnpm typecheck:repo && pnpm test`
