### PR TITLE
fix: add stale-session recovery hints for missing mcp sessions

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -56,6 +56,14 @@ Transport / client integration:
   - This avoids granting Codex any vault filesystem permissions.
   - The plugin remains the only writer (vault DB writes + gated note edits via MCP write tools).
   - Supports multiple concurrent MCP sessions (multiple Codex CLI processes), each with its own `Mcp-Session-Id`.
+  - Stale-session recovery contract: if a non-`initialize` request uses an expired/evicted `Mcp-Session-Id`, the server responds with HTTP `404` + JSON-RPC `-32001` (`Session not found`) and `error.data`:
+    - `reason: "session_expired_or_evicted"`
+    - `reinitializeRequired: true`
+    - `retryRequest: true`
+  - Recommended client retry flow for that error:
+    - Drop cached session ID
+    - Send a fresh `initialize` request to obtain a new `Mcp-Session-Id`
+    - Retry the original request once with the new session ID
 - Local dev still supports running the MCP server over stdio (CLI).
 - Optional shutdown endpoint (disabled by default):
   - If `AILSS_MCP_HTTP_SHUTDOWN_TOKEN` is set (or `startAilssMcpHttpServer({ shutdown: { token } })` is used), the server exposes `POST /__ailss/shutdown`.

--- a/packages/mcp/test/httpSessions.sessionLifecycle.test.ts
+++ b/packages/mcp/test/httpSessions.sessionLifecycle.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 
 import {
   mcpDeleteSession,
+  mcpDeleteSessionExpectSessionNotFound,
   mcpInitialize,
   mcpInitializeExpectUnauthorized,
   mcpToolsList,
@@ -62,6 +63,7 @@ describe("MCP HTTP server (multi-session)", () => {
           await mcpToolsList(url, token, sessionId);
 
           await mcpDeleteSession(url, token, sessionId);
+          await mcpDeleteSessionExpectSessionNotFound(url, token, sessionId);
           await mcpToolsListExpectSessionNotFound(url, token, sessionId);
         },
       );

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -337,8 +337,24 @@ export async function mcpToolsListExpectSessionNotFound(
   });
 
   expect(res.status).toBe(404);
-  const payload = (await res.json()) as { error?: { code?: number; message?: string } };
+  const payload = (await res.json()) as {
+    error?: {
+      code?: number;
+      message?: string;
+      data?: {
+        reason?: string;
+        reinitializeRequired?: boolean;
+        retryRequest?: boolean;
+      };
+    };
+  };
   expect(payload.error?.code).toBe(-32001);
+  expect(payload.error?.message).toBe("Session not found");
+  expect(payload.error?.data).toMatchObject({
+    reason: "session_expired_or_evicted",
+    reinitializeRequired: true,
+    retryRequest: true,
+  });
 }
 
 export async function mcpToolsListExpectBadRequest(url: string, token: string): Promise<void> {


### PR DESCRIPTION
## What

- Added structured recovery hints (`reason`, `reinitializeRequired`, `retryRequest`) to HTTP `404` / JSON-RPC `-32001` session-not-found responses in MCP HTTP routes.
- Extended MCP HTTP session-lifecycle test helper assertions so stale-session responses must include the recovery-hint contract.

## Why

- Stale or evicted `mcp-session-id` values could trap long-running clients in repeated failure loops without a machine-readable recovery contract.
- Fixes #106

## How

- Updated `sendJsonRpcError` to optionally include `error.data`, then attached recovery hints for stale-session failures.
- Documented the recommended retry flow (drop stale session ID -> re-initialize -> retry once) in the transport integration docs.
- Validation: `pnpm format:check`, `pnpm lint`, `pnpm typecheck`, `pnpm typecheck:repo`, `pnpm test` (via pre-push hook).
