### PR TITLE
feat: add structured mcp tool failure diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Full rules: `docs/standards/vault/README.md`.
 
 Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 
-- Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`
+- Read tools: `get_context`, `expand_typed_links_outgoing`, `resolve_note`, `read_note`, `search_notes`, `list_tags`, `list_keywords`, `find_broken_links`, `frontmatter_validate`, `find_typed_links_incoming`, `get_tool_failure_report`
 - Write tools (gated): `capture_note`, `canonicalize_typed_links`, `edit_note`, `improve_frontmatter`, `relocate_note`  
   Requires `AILSS_ENABLE_WRITE_TOOLS=1` and `apply=true`.
 

--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -45,6 +45,7 @@ Read-first tools (implemented in this repo):
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `get_tool_failure_report`: summarize MCP tool failure logs from `<vault>/.ailss/logs` (recent events + top recurring error types)
 
 Client guidance (Codex):
 

--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -24,7 +24,7 @@ It also records a few **hard decisions** so code and docs stay consistent.
   - Full-vault runs prune DB entries for deleted files
   - Has a deterministic wrapper test (stubbed embeddings; no network)
 - MCP server MVP exists (`packages/mcp`)
-- Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`
+- Read-first tools: `get_context`, `expand_typed_links_outgoing`, `find_typed_links_incoming`, `resolve_note`, `read_note`, `get_vault_tree`, `frontmatter_validate`, `find_broken_links`, `search_notes`, `list_tags`, `list_keywords`, `get_tool_failure_report`
 - Explicit write tools (gated; `AILSS_ENABLE_WRITE_TOOLS=1`): `capture_note`, `canonicalize_typed_links`, `edit_note`, `improve_frontmatter`, `relocate_note`
   - Transport: stdio + streamable HTTP (`/mcp` on localhost; supports multiple concurrent sessions)
 - Obsidian plugin MVP exists (`packages/obsidian-plugin`)
@@ -131,6 +131,7 @@ Implemented:
 - `search_notes`: search indexed note metadata (frontmatter-derived fields, tags/keywords/sources) without embeddings
 - `list_tags`: list indexed tags with usage counts
 - `list_keywords`: list indexed keywords with usage counts
+- `get_tool_failure_report`: summarize MCP tool failure logs from `<vault>/.ailss/logs` (recent events + top recurring error types)
 
 Notes on queryability (current):
 

--- a/docs/ops/codex-skills/prometheus-agent/SKILL.md
+++ b/docs/ops/codex-skills/prometheus-agent/SKILL.md
@@ -14,6 +14,7 @@ mcp_tools:
   - search_notes
   - list_tags
   - list_keywords
+  - get_tool_failure_report
   # Only when write tools are enabled (AILSS_ENABLE_WRITE_TOOLS=1)
   - capture_note
   - canonicalize_typed_links

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -120,6 +120,19 @@ Source of truth: `packages/mcp/src/tools/*.ts`.
 - Input:
   - `limit` (int, default: `200`, range: `1–5000`)
 
+### `get_tool_failure_report`
+
+- Purpose: summarize structured MCP tool failure logs (JSONL) from `<vault>/.ailss/logs`.
+- Input:
+  - `recent_limit` (int, default: `50`, range: `1–500`) — recent events to return (newest first)
+  - `top_error_limit` (int, default: `10`, range: `1–50`) — top recurring error buckets
+  - `tool` (string, optional) — filter report to one tool name (e.g. `read_note`)
+- Output highlights:
+  - `enabled`: whether diagnostics logging is active (requires `AILSS_VAULT_PATH`)
+  - `log_dir`, `log_path`: actual diagnostics file location
+  - `top_error_types`: grouped counts with first/last occurrence
+  - `recent_events`: per-failure metadata (`timestamp`, `tool`, `input_path`, `resolved_path`, `error`, `request_id`, `session_id`, `correlation_id`)
+
 ## Write tools (gated)
 
 Write tools are registered only when `AILSS_ENABLE_WRITE_TOOLS=1` and they only write when `apply=true`.

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -86,14 +86,18 @@ function installToolFailureDiagnostics(server: McpServer, deps: McpToolDeps): vo
       try {
         return await cb(...toolCallbackArgs);
       } catch (error) {
-        await diagnostics.logToolFailure({
-          tool: name,
-          operation: "tool_call",
-          args: toolArgs,
-          error,
-          requestId: extra?.requestId,
-          sessionId: extra?.sessionId,
-        });
+        try {
+          await diagnostics.logToolFailure({
+            tool: name,
+            operation: "tool_call",
+            args: toolArgs,
+            error,
+            requestId: extra?.requestId,
+            sessionId: extra?.sessionId,
+          });
+        } catch {
+          // Fail-open diagnostics
+        }
         throw error;
       }
     })) as McpServer["registerTool"];

--- a/packages/mcp/src/createAilssMcpServer.ts
+++ b/packages/mcp/src/createAilssMcpServer.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { AsyncMutex } from "./lib/asyncMutex.js";
 import { embeddingDimForModel } from "./lib/openaiEmbeddings.js";
+import { createMcpToolFailureDiagnostics } from "./lib/toolFailureDiagnostics.js";
 import type { McpToolDeps } from "./mcpDeps.js";
 import { registerCaptureNoteTool } from "./tools/captureNote.js";
 import { registerCanonicalizeTypedLinksTool } from "./tools/canonicalizeTypedLinks.js";
@@ -15,6 +16,7 @@ import { registerFindTypedLinksIncomingTool } from "./tools/findTypedLinksIncomi
 import { registerFrontmatterValidateTool } from "./tools/frontmatterValidate.js";
 import { registerGetContextTool } from "./tools/getContext.js";
 import { registerGetNoteTool } from "./tools/getNote.js";
+import { registerGetToolFailureReportTool } from "./tools/getToolFailureReport.js";
 import { registerGetVaultTreeTool } from "./tools/getVaultTree.js";
 import { registerImproveFrontmatterTool } from "./tools/improveFrontmatter.js";
 import { registerListKeywordsTool } from "./tools/listKeywords.js";
@@ -27,6 +29,77 @@ export type AilssMcpRuntime = {
   deps: McpToolDeps;
   enableWriteTools: boolean;
 };
+
+type ToolCallbackExtra = {
+  requestId?: unknown;
+  sessionId?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isToolCallbackExtra(value: unknown): value is ToolCallbackExtra {
+  return isRecord(value) && "requestId" in value;
+}
+
+function splitToolCallbackArgs(args: unknown[]): {
+  toolArgs: unknown;
+  extra: ToolCallbackExtra | undefined;
+} {
+  if (args.length === 0) {
+    return { toolArgs: undefined, extra: undefined };
+  }
+
+  if (args.length === 1) {
+    const first = args[0];
+    if (isToolCallbackExtra(first)) return { toolArgs: undefined, extra: first };
+    return { toolArgs: first, extra: undefined };
+  }
+
+  const second = args[1];
+  return {
+    toolArgs: args[0],
+    extra: isToolCallbackExtra(second) ? second : undefined,
+  };
+}
+
+function installToolFailureDiagnostics(server: McpServer, deps: McpToolDeps): void {
+  const diagnostics = deps.toolFailureDiagnostics;
+  if (!diagnostics?.enabled) return;
+
+  type UntypedRegisterTool = (
+    name: string,
+    config: unknown,
+    cb: (...args: unknown[]) => unknown,
+  ) => unknown;
+
+  const originalRegisterTool = server.registerTool.bind(server) as unknown as UntypedRegisterTool;
+  const wrappedRegisterTool = ((
+    name: string,
+    config: unknown,
+    cb: (...args: unknown[]) => unknown,
+  ) =>
+    originalRegisterTool(name, config, async (...toolCallbackArgs: unknown[]) => {
+      const { toolArgs, extra } = splitToolCallbackArgs(toolCallbackArgs);
+
+      try {
+        return await cb(...toolCallbackArgs);
+      } catch (error) {
+        await diagnostics.logToolFailure({
+          tool: name,
+          operation: "tool_call",
+          args: toolArgs,
+          error,
+          requestId: extra?.requestId,
+          sessionId: extra?.sessionId,
+        });
+        throw error;
+      }
+    })) as McpServer["registerTool"];
+
+  server.registerTool = wrappedRegisterTool;
+}
 
 export async function createAilssMcpRuntimeFromEnv(): Promise<AilssMcpRuntime> {
   const env = loadEnv();
@@ -56,6 +129,10 @@ export async function createAilssMcpRuntimeFromEnv(): Promise<AilssMcpRuntime> {
       openai,
       embeddingModel,
       writeLock: new AsyncMutex(),
+      toolFailureDiagnostics: createMcpToolFailureDiagnostics({
+        vaultPath,
+        cwd: process.cwd(),
+      }),
     },
     enableWriteTools: env.enableWriteTools,
   };
@@ -68,6 +145,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   const deps = runtime.deps;
 
   const server = new McpServer({ name: "ailss-mcp", version: "0.1.0" });
+  installToolFailureDiagnostics(server, deps);
 
   registerGetContextTool(server, deps);
   registerExpandTypedLinksOutgoingTool(server, deps);
@@ -80,6 +158,7 @@ export function createAilssMcpServerFromRuntime(runtime: AilssMcpRuntime): {
   registerListTagsTool(server, deps);
   registerListKeywordsTool(server, deps);
   registerFindTypedLinksIncomingTool(server, deps);
+  registerGetToolFailureReportTool(server, deps);
 
   if (runtime.enableWriteTools) {
     registerCaptureNoteTool(server, deps);

--- a/packages/mcp/src/lib/toolFailureDiagnostics.ts
+++ b/packages/mcp/src/lib/toolFailureDiagnostics.ts
@@ -1,0 +1,332 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+type JsonRecord = Record<string, unknown>;
+
+export type McpToolFailureEvent = {
+  timestamp: string;
+  tool: string;
+  operation: string;
+  input_path: string | null;
+  resolved_path: string | null;
+  error: {
+    code: string | null;
+    name: string | null;
+    message: string;
+  };
+  cwd: string;
+  vault_root: string | null;
+  request_id: string | number | null;
+  session_id: string | null;
+  correlation_id: string | null;
+};
+
+export type McpToolFailureTypeSummary = {
+  tool: string;
+  error_code: string | null;
+  error_name: string | null;
+  count: number;
+  first_timestamp: string;
+  last_timestamp: string;
+  sample_message: string;
+};
+
+export type McpToolFailureReport = {
+  enabled: boolean;
+  log_dir: string | null;
+  log_path: string | null;
+  scanned_events: number;
+  matched_events: number;
+  first_timestamp: string | null;
+  last_timestamp: string | null;
+  top_error_types: McpToolFailureTypeSummary[];
+  recent_events: McpToolFailureEvent[];
+};
+
+export type LogMcpToolFailureOptions = {
+  tool: string;
+  operation?: string;
+  args?: unknown;
+  error: unknown;
+  requestId?: unknown;
+  sessionId?: unknown;
+};
+
+export type GetToolFailureReportOptions = {
+  recentLimit: number;
+  topErrorLimit: number;
+  tool?: string;
+};
+
+export type McpToolFailureDiagnostics = {
+  enabled: boolean;
+  logDir: string | null;
+  logPath: string | null;
+  logToolFailure(options: LogMcpToolFailureOptions): Promise<void>;
+  getToolFailureReport(options: GetToolFailureReportOptions): Promise<McpToolFailureReport>;
+};
+
+const LOG_FILE_NAME = "mcp-tool-failures.jsonl";
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toNullableString(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return null;
+}
+
+function toRequestId(value: unknown): string | number | null {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return null;
+}
+
+function extractPrimaryInputPath(args: unknown): string | null {
+  if (!isRecord(args)) return null;
+
+  const pathLikeKeys = ["path", "input_path", "from_path", "to_path"] as const;
+  for (const key of pathLikeKeys) {
+    const value = args[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function normalizeError(error: unknown): {
+  code: string | null;
+  name: string | null;
+  message: string;
+} {
+  if (error instanceof Error) {
+    const rawCode = (error as NodeJS.ErrnoException).code;
+    const code =
+      typeof rawCode === "string" ? rawCode : typeof rawCode === "number" ? String(rawCode) : null;
+    return {
+      code,
+      name: error.name || null,
+      message: error.message || "Unknown error",
+    };
+  }
+
+  if (isRecord(error)) {
+    const code = toNullableString(error["code"]);
+    const name = toNullableString(error["name"]);
+    const message = toNullableString(error["message"]) ?? JSON.stringify(error);
+    return { code, name, message };
+  }
+
+  return { code: null, name: null, message: String(error) };
+}
+
+function correlationIdFor(
+  requestId: string | number | null,
+  sessionId: string | null,
+): string | null {
+  if (requestId === null && sessionId === null) return null;
+  const sid = sessionId ?? "no-session";
+  const rid = requestId ?? "no-request";
+  return `${sid}:${rid}`;
+}
+
+function toResolvedPath(vaultRoot: string | null, inputPath: string | null): string | null {
+  if (!vaultRoot || !inputPath) return null;
+  return path.resolve(vaultRoot, inputPath);
+}
+
+function parseEvent(raw: unknown): McpToolFailureEvent | null {
+  if (!isRecord(raw)) return null;
+  if (!isRecord(raw["error"])) return null;
+
+  const timestamp = toNullableString(raw["timestamp"]);
+  const tool = toNullableString(raw["tool"]);
+  const operation = toNullableString(raw["operation"]);
+  const cwd = toNullableString(raw["cwd"]);
+  const message = toNullableString(raw["error"]["message"]);
+
+  if (!timestamp || !tool || !operation || !cwd || !message) return null;
+
+  return {
+    timestamp,
+    tool,
+    operation,
+    input_path: toNullableString(raw["input_path"]),
+    resolved_path: toNullableString(raw["resolved_path"]),
+    error: {
+      code: toNullableString(raw["error"]["code"]),
+      name: toNullableString(raw["error"]["name"]),
+      message,
+    },
+    cwd,
+    vault_root: toNullableString(raw["vault_root"]),
+    request_id: toRequestId(raw["request_id"]),
+    session_id: toNullableString(raw["session_id"]),
+    correlation_id: toNullableString(raw["correlation_id"]),
+  };
+}
+
+async function readEventsFromJsonl(logPath: string | null): Promise<McpToolFailureEvent[]> {
+  if (!logPath) return [];
+
+  let text: string;
+  try {
+    text = await fs.readFile(logPath, "utf8");
+  } catch (error) {
+    const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+    if (code === "ENOENT") return [];
+    throw error;
+  }
+
+  const events: McpToolFailureEvent[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      const event = parseEvent(parsed);
+      if (event) events.push(event);
+    } catch {
+      // Skip malformed rows to keep diagnostics resilient.
+    }
+  }
+
+  return events;
+}
+
+function summarizeTopErrors(
+  events: McpToolFailureEvent[],
+  topErrorLimit: number,
+): McpToolFailureTypeSummary[] {
+  type Bucket = {
+    tool: string;
+    error_code: string | null;
+    error_name: string | null;
+    count: number;
+    first_timestamp: string;
+    last_timestamp: string;
+    sample_message: string;
+  };
+
+  const buckets = new Map<string, Bucket>();
+
+  for (const event of events) {
+    const bucketKey = `${event.tool}::${event.error.code ?? ""}::${event.error.name ?? ""}`;
+    const existing = buckets.get(bucketKey);
+    if (!existing) {
+      buckets.set(bucketKey, {
+        tool: event.tool,
+        error_code: event.error.code,
+        error_name: event.error.name,
+        count: 1,
+        first_timestamp: event.timestamp,
+        last_timestamp: event.timestamp,
+        sample_message: event.error.message,
+      });
+      continue;
+    }
+
+    existing.count += 1;
+    if (event.timestamp < existing.first_timestamp) existing.first_timestamp = event.timestamp;
+    if (event.timestamp > existing.last_timestamp) {
+      existing.last_timestamp = event.timestamp;
+      existing.sample_message = event.error.message;
+    }
+  }
+
+  return [...buckets.values()]
+    .sort((a, b) => b.count - a.count || b.last_timestamp.localeCompare(a.last_timestamp))
+    .slice(0, topErrorLimit);
+}
+
+export function createMcpToolFailureDiagnostics(options: {
+  vaultPath: string | undefined;
+  cwd: string;
+}): McpToolFailureDiagnostics {
+  const vaultRoot = options.vaultPath ?? null;
+  const enabled = Boolean(vaultRoot);
+  const logDir = vaultRoot ? path.join(vaultRoot, ".ailss", "logs") : null;
+  const logPath = logDir ? path.join(logDir, LOG_FILE_NAME) : null;
+
+  let writeChain: Promise<void> = Promise.resolve();
+
+  const enqueueWrite = async (line: string): Promise<void> => {
+    if (!logDir || !logPath) return;
+
+    writeChain = writeChain
+      .then(async () => {
+        await fs.mkdir(logDir, { recursive: true });
+        await fs.appendFile(logPath, `${line}\n`, "utf8");
+      })
+      .catch(() => undefined);
+
+    await writeChain;
+  };
+
+  const logToolFailure = async (logOptions: LogMcpToolFailureOptions): Promise<void> => {
+    if (!enabled) return;
+
+    const inputPath = extractPrimaryInputPath(logOptions.args);
+    const requestId = toRequestId(logOptions.requestId);
+    const sessionId = toNullableString(logOptions.sessionId);
+
+    const event: McpToolFailureEvent = {
+      timestamp: new Date().toISOString(),
+      tool: logOptions.tool,
+      operation: logOptions.operation ?? "tool_call",
+      input_path: inputPath,
+      resolved_path: toResolvedPath(vaultRoot, inputPath),
+      error: normalizeError(logOptions.error),
+      cwd: options.cwd,
+      vault_root: vaultRoot,
+      request_id: requestId,
+      session_id: sessionId,
+      correlation_id: correlationIdFor(requestId, sessionId),
+    };
+
+    try {
+      await enqueueWrite(JSON.stringify(event));
+    } catch {
+      // Never fail a tool call because diagnostics logging failed.
+    }
+  };
+
+  const getToolFailureReport = async (
+    reportOptions: GetToolFailureReportOptions,
+  ): Promise<McpToolFailureReport> => {
+    const recentLimit = Math.max(1, Math.floor(reportOptions.recentLimit));
+    const topErrorLimit = Math.max(1, Math.floor(reportOptions.topErrorLimit));
+    const toolFilter = reportOptions.tool?.trim();
+
+    const events = await readEventsFromJsonl(logPath);
+    const filtered = toolFilter ? events.filter((event) => event.tool === toolFilter) : events;
+
+    const firstTimestamp = filtered.length > 0 ? (filtered[0]?.timestamp ?? null) : null;
+    const lastTimestamp =
+      filtered.length > 0 ? (filtered[filtered.length - 1]?.timestamp ?? null) : null;
+
+    return {
+      enabled,
+      log_dir: logDir,
+      log_path: logPath,
+      scanned_events: events.length,
+      matched_events: filtered.length,
+      first_timestamp: firstTimestamp,
+      last_timestamp: lastTimestamp,
+      top_error_types: summarizeTopErrors(filtered, topErrorLimit),
+      recent_events: filtered.slice(-recentLimit).reverse(),
+    };
+  };
+
+  return {
+    enabled,
+    logDir,
+    logPath,
+    logToolFailure,
+    getToolFailureReport,
+  };
+}

--- a/packages/mcp/src/mcpDeps.ts
+++ b/packages/mcp/src/mcpDeps.ts
@@ -3,6 +3,8 @@
 import type { AilssDb } from "@ailss/core";
 import type OpenAI from "openai";
 
+import type { McpToolFailureDiagnostics } from "./lib/toolFailureDiagnostics.js";
+
 export type WriteLock = {
   runExclusive<T>(fn: () => Promise<T>): Promise<T>;
 };
@@ -14,4 +16,5 @@ export type McpToolDeps = {
   openai: OpenAI;
   embeddingModel: string;
   writeLock?: WriteLock;
+  toolFailureDiagnostics?: McpToolFailureDiagnostics;
 };

--- a/packages/mcp/src/tools/getToolFailureReport.ts
+++ b/packages/mcp/src/tools/getToolFailureReport.ts
@@ -6,6 +6,20 @@ import { z } from "zod";
 
 import type { McpToolDeps } from "../mcpDeps.js";
 
+function createDisabledReport() {
+  return {
+    enabled: false,
+    log_dir: null,
+    log_path: null,
+    scanned_events: 0,
+    matched_events: 0,
+    first_timestamp: null,
+    last_timestamp: null,
+    top_error_types: [],
+    recent_events: [],
+  };
+}
+
 export function registerGetToolFailureReportTool(server: McpServer, deps: McpToolDeps): void {
   server.registerTool(
     "get_tool_failure_report",
@@ -77,15 +91,13 @@ export function registerGetToolFailureReportTool(server: McpServer, deps: McpToo
     },
     async (args) => {
       const diagnostics = deps.toolFailureDiagnostics;
-      if (!diagnostics) {
-        throw new Error("Tool failure diagnostics are unavailable.");
-      }
-
-      const report = await diagnostics.getToolFailureReport({
-        recentLimit: args.recent_limit,
-        topErrorLimit: args.top_error_limit,
-        ...(args.tool ? { tool: args.tool } : {}),
-      });
+      const report = diagnostics
+        ? await diagnostics.getToolFailureReport({
+            recentLimit: args.recent_limit,
+            topErrorLimit: args.top_error_limit,
+            ...(args.tool ? { tool: args.tool } : {}),
+          })
+        : createDisabledReport();
 
       return {
         structuredContent: report,

--- a/packages/mcp/src/tools/getToolFailureReport.ts
+++ b/packages/mcp/src/tools/getToolFailureReport.ts
@@ -1,0 +1,96 @@
+// get_tool_failure_report tool
+// - MCP tool failure diagnostics summary
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import type { McpToolDeps } from "../mcpDeps.js";
+
+export function registerGetToolFailureReportTool(server: McpServer, deps: McpToolDeps): void {
+  server.registerTool(
+    "get_tool_failure_report",
+    {
+      title: "Get tool failure report",
+      description:
+        "Summarizes structured MCP tool failure logs from `<vault>/.ailss/logs` as recent events and top recurring error types.",
+      inputSchema: {
+        recent_limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(500)
+          .default(50)
+          .describe("How many recent events to return (newest first)."),
+        top_error_limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(50)
+          .default(10)
+          .describe("How many top error buckets to return."),
+        tool: z
+          .string()
+          .trim()
+          .min(1)
+          .optional()
+          .describe("Optional tool name filter (e.g. `read_note`)."),
+      },
+      outputSchema: z.object({
+        enabled: z.boolean(),
+        log_dir: z.string().nullable(),
+        log_path: z.string().nullable(),
+        scanned_events: z.number().int().nonnegative(),
+        matched_events: z.number().int().nonnegative(),
+        first_timestamp: z.string().nullable(),
+        last_timestamp: z.string().nullable(),
+        top_error_types: z.array(
+          z.object({
+            tool: z.string(),
+            error_code: z.string().nullable(),
+            error_name: z.string().nullable(),
+            count: z.number().int().nonnegative(),
+            first_timestamp: z.string(),
+            last_timestamp: z.string(),
+            sample_message: z.string(),
+          }),
+        ),
+        recent_events: z.array(
+          z.object({
+            timestamp: z.string(),
+            tool: z.string(),
+            operation: z.string(),
+            input_path: z.string().nullable(),
+            resolved_path: z.string().nullable(),
+            error: z.object({
+              code: z.string().nullable(),
+              name: z.string().nullable(),
+              message: z.string(),
+            }),
+            cwd: z.string(),
+            vault_root: z.string().nullable(),
+            request_id: z.union([z.string(), z.number()]).nullable(),
+            session_id: z.string().nullable(),
+            correlation_id: z.string().nullable(),
+          }),
+        ),
+      }),
+    },
+    async (args) => {
+      const diagnostics = deps.toolFailureDiagnostics;
+      if (!diagnostics) {
+        throw new Error("Tool failure diagnostics are unavailable.");
+      }
+
+      const report = await diagnostics.getToolFailureReport({
+        recentLimit: args.recent_limit,
+        topErrorLimit: args.top_error_limit,
+        ...(args.tool ? { tool: args.tool } : {}),
+      });
+
+      return {
+        structuredContent: report,
+        content: [{ type: "text", text: JSON.stringify(report, null, 2) }],
+      };
+    },
+  );
+}

--- a/packages/mcp/test/httpTools.toolFailureReport.test.ts
+++ b/packages/mcp/test/httpTools.toolFailureReport.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  assertArray,
+  assertRecord,
+  getStructuredContent,
+  mcpInitialize,
+  mcpToolsCall,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+function expectToolCallErrorResult(payload: unknown): void {
+  assertRecord(payload, "JSON-RPC payload");
+  const result = payload["result"];
+  assertRecord(result, "JSON-RPC result");
+  expect(result["isError"]).toBe(true);
+}
+
+describe("MCP HTTP server (tool failure diagnostics)", () => {
+  it("stores failed tool calls and summarizes them via get_tool_failure_report", async () => {
+    await withTempDir("ailss-mcp-http-", async (vaultPath) => {
+      await withMcpHttpServer({ vaultPath, enableWriteTools: false }, async ({ url, token }) => {
+        const sessionId = await mcpInitialize(url, token, "client-a");
+
+        const failed = await mcpToolsCall(url, token, sessionId, "read_note", {
+          path: "Missing/Doc.md",
+          max_chars: 5_000,
+        });
+        expectToolCallErrorResult(failed);
+
+        const reportPayload = await mcpToolsCall(url, token, sessionId, "get_tool_failure_report", {
+          recent_limit: 10,
+          top_error_limit: 5,
+        });
+
+        const structured = getStructuredContent(reportPayload);
+        expect(structured["enabled"]).toBe(true);
+        expect(structured["log_dir"]).toBe(path.join(vaultPath, ".ailss", "logs"));
+        expect(structured["log_path"]).toBe(
+          path.join(vaultPath, ".ailss", "logs", "mcp-tool-failures.jsonl"),
+        );
+        expect(structured["matched_events"]).toBe(1);
+        expect(structured["scanned_events"]).toBe(1);
+
+        const topErrorTypes = structured["top_error_types"];
+        assertArray(topErrorTypes, "top_error_types");
+        expect(topErrorTypes.length).toBe(1);
+        assertRecord(topErrorTypes[0], "top_error_types[0]");
+        expect(topErrorTypes[0]["tool"]).toBe("read_note");
+        expect(topErrorTypes[0]["error_code"]).toBe("ENOENT");
+
+        const recentEvents = structured["recent_events"];
+        assertArray(recentEvents, "recent_events");
+        expect(recentEvents.length).toBe(1);
+        assertRecord(recentEvents[0], "recent_events[0]");
+        expect(recentEvents[0]["tool"]).toBe("read_note");
+        expect(recentEvents[0]["operation"]).toBe("tool_call");
+        expect(recentEvents[0]["input_path"]).toBe("Missing/Doc.md");
+        expect(recentEvents[0]["resolved_path"]).toBe(path.join(vaultPath, "Missing", "Doc.md"));
+
+        const error = recentEvents[0]["error"];
+        assertRecord(error, "recent_events[0].error");
+        expect(error["code"]).toBe("ENOENT");
+        expect(typeof error["message"]).toBe("string");
+
+        const logPath = path.join(vaultPath, ".ailss", "logs", "mcp-tool-failures.jsonl");
+        const logText = await fs.readFile(logPath, "utf8");
+        const rows = logText
+          .split("\n")
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0);
+        expect(rows.length).toBe(1);
+
+        const logged = JSON.parse(rows[0] ?? "{}") as Record<string, unknown>;
+        expect(logged["tool"]).toBe("read_note");
+        expect(logged["input_path"]).toBe("Missing/Doc.md");
+      });
+    });
+  });
+
+  it("returns disabled report state without AILSS_VAULT_PATH", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const sessionId = await mcpInitialize(url, token, "client-a");
+        const reportPayload = await mcpToolsCall(url, token, sessionId, "get_tool_failure_report", {
+          recent_limit: 10,
+          top_error_limit: 5,
+        });
+
+        const structured = getStructuredContent(reportPayload);
+        expect(structured["enabled"]).toBe(false);
+        expect(structured["log_dir"]).toBe(null);
+        expect(structured["log_path"]).toBe(null);
+        expect(structured["scanned_events"]).toBe(0);
+        expect(structured["matched_events"]).toBe(0);
+
+        const recentEvents = structured["recent_events"];
+        assertArray(recentEvents, "recent_events");
+        expect(recentEvents.length).toBe(0);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## What

- Add a shared MCP tool failure diagnostics module that writes structured JSONL events.
- Register a new read tool, `get_tool_failure_report`, for recent failures and top recurring error types.
- Add integration tests covering failure capture, report output, and disabled behavior without `AILSS_VAULT_PATH`.

## Why

- Preserve a durable failure trail for MCP tool-call errors (for example `read_note` ENOENT/path mismatch cases).
- Make repeated failure patterns visible without manual log scraping.
- Fixes #105

## How

- Wrap `McpServer.registerTool` at server wiring to capture handler exceptions with request/session correlation metadata.
- Persist events to `<vault>/.ailss/logs/mcp-tool-failures.jsonl` and compute report aggregates from the JSONL file.
- Update MCP surface documentation and Codex skill metadata to include the new diagnostics tool.
