### PR TITLE
fix: decoder-safe MCP HTTP errors and durable plugin diagnostics

### DIFF
--- a/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
+++ b/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
@@ -1,6 +1,8 @@
 import { Notice } from "obsidian";
 import { spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
 import http from "node:http";
+import path from "node:path";
 
 import { DEFAULT_SETTINGS, type AilssObsidianSettings } from "../settings.js";
 import { clampPort, clampTopK } from "../utils/clamp.js";
@@ -44,6 +46,9 @@ type SpawnPlan = {
 	env: NodeJS.ProcessEnv;
 };
 
+const MCP_HTTP_LOG_DIR = ".ailss";
+const MCP_HTTP_LOG_FILE = "ailss-mcp-http-last.log";
+
 export class McpHttpServiceController {
 	private proc: ChildProcess | null = null;
 	private stopRequested = false;
@@ -53,6 +58,8 @@ export class McpHttpServiceController {
 	private lastExitCode: number | null = null;
 	private lastStoppedAt: string | null = null;
 	private lastErrorMessage: string | null = null;
+	private durableLogPath: string | null = null;
+	private durableLogWriteQueue: Promise<void> = Promise.resolve();
 
 	constructor(private readonly deps: McpHttpServiceControllerDeps) {}
 
@@ -336,6 +343,47 @@ export class McpHttpServiceController {
 		this.lastExitCode = null;
 		this.lastStoppedAt = null;
 		this.lastErrorMessage = null;
+		this.initializeDurableLog();
+	}
+
+	private initializeDurableLog(): void {
+		const vaultPath = this.deps.getVaultPath().trim();
+		if (!vaultPath) {
+			this.durableLogPath = null;
+			this.durableLogWriteQueue = Promise.resolve();
+			return;
+		}
+
+		const dir = path.join(vaultPath, MCP_HTTP_LOG_DIR);
+		const filePath = path.join(dir, MCP_HTTP_LOG_FILE);
+		this.durableLogPath = filePath;
+		this.durableLogWriteQueue = Promise.resolve();
+
+		const header = [`[time] ${nowIso()}`, "[event] mcp-http-service-start", ""].join("\n");
+		this.enqueueDurableLogWrite(async () => {
+			await fs.promises.mkdir(dir, { recursive: true });
+			await fs.promises.writeFile(filePath, header, "utf8");
+		});
+	}
+
+	private enqueueDurableLogWrite(task: () => Promise<void>): void {
+		this.durableLogWriteQueue = this.durableLogWriteQueue.then(task).catch((error) => {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`[ailss-mcp-http] durable log write failed: ${message}`);
+		});
+	}
+
+	private appendDurableLogChunk(stream: "stdout" | "stderr", chunk: string): void {
+		const filePath = this.durableLogPath;
+		if (!filePath || !chunk) return;
+
+		const content = chunk.trimEnd();
+		if (!content) return;
+
+		const entry = [`[time] ${nowIso()}`, `[stream] ${stream}`, content, ""].join("\n");
+		this.enqueueDurableLogWrite(async () => {
+			await fs.promises.appendFile(filePath, entry, "utf8");
+		});
 	}
 
 	private spawnServiceProcess(plan: SpawnPlan): ChildProcess {
@@ -350,11 +398,13 @@ export class McpHttpServiceController {
 		child.stdout?.on("data", (chunk: unknown) => {
 			const text = typeof chunk === "string" ? chunk : String(chunk);
 			this.liveStdout = appendLimited(this.liveStdout, text, 40_000);
+			this.appendDurableLogChunk("stdout", text);
 		});
 
 		child.stderr?.on("data", (chunk: unknown) => {
 			const text = typeof chunk === "string" ? chunk : String(chunk);
 			this.liveStderr = appendLimited(this.liveStderr, text, 40_000);
+			this.appendDurableLogChunk("stderr", text);
 		});
 
 		child.on("error", (error) => {
@@ -397,9 +447,10 @@ export class McpHttpServiceController {
 		const stderr = this.liveStderr.trim();
 		const stderrTail = stderr ? stderr.split(/\r?\n/).slice(-10).join("\n").trim() : "";
 		const suffix = code === null ? `signal ${signal}` : `exit ${code}`;
+		const logHint = this.durableLogPath ? `\nMCP log file: ${this.durableLogPath}` : "";
 		return stderrTail
-			? `Unexpected stop (${suffix}). Last stderr:\n${stderrTail}`
-			: `Unexpected stop (${suffix}).`;
+			? `Unexpected stop (${suffix}). Last stderr:\n${stderrTail}${logHint}`
+			: `Unexpected stop (${suffix}).${logHint}`;
 	}
 
 	private async requestShutdown(options: {

--- a/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
+++ b/packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts
@@ -350,14 +350,12 @@ export class McpHttpServiceController {
 		const vaultPath = this.deps.getVaultPath().trim();
 		if (!vaultPath) {
 			this.durableLogPath = null;
-			this.durableLogWriteQueue = Promise.resolve();
 			return;
 		}
 
 		const dir = path.join(vaultPath, MCP_HTTP_LOG_DIR);
 		const filePath = path.join(dir, MCP_HTTP_LOG_FILE);
 		this.durableLogPath = filePath;
-		this.durableLogWriteQueue = Promise.resolve();
 
 		const header = [`[time] ${nowIso()}`, "[event] mcp-http-service-start", ""].join("\n");
 		this.enqueueDurableLogWrite(async () => {

--- a/packages/obsidian-plugin/test/mcp/mcpHttpServiceController.startupHelpers.test.ts
+++ b/packages/obsidian-plugin/test/mcp/mcpHttpServiceController.startupHelpers.test.ts
@@ -1,4 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 vi.mock("../../src/utils/tcp.js", () => ({
 	waitForTcpPortToBeAvailable: vi.fn(),
@@ -35,6 +38,9 @@ type ControllerInternals = {
 		port: number;
 		tokens: string[];
 	}) => Promise<boolean>;
+	resetStartupState: () => void;
+	appendDurableLogChunk: (stream: "stdout" | "stderr", chunk: string) => void;
+	durableLogWriteQueue: Promise<void>;
 	lastErrorMessage: string | null;
 };
 
@@ -66,6 +72,7 @@ function createController(
 	options: {
 		settings?: TestSettings;
 		resolveMcpHttpArgs?: () => string[];
+		vaultPath?: string;
 	} = {},
 ) {
 	const settings = options.settings ?? createSettings();
@@ -75,7 +82,7 @@ function createController(
 	const deps: McpHttpServiceControllerDeps = {
 		getSettings: () => settings,
 		saveSettings,
-		getVaultPath: () => "/vault",
+		getVaultPath: () => options.vaultPath ?? "/vault",
 		getPluginDirRealpathOrNull: () => "/plugin",
 		resolveMcpHttpArgs: options.resolveMcpHttpArgs ?? (() => settings.mcpArgs),
 		getUrl: () => "http://127.0.0.1:31415/mcp",
@@ -310,6 +317,32 @@ describe("McpHttpServiceController startup helper unit branches", () => {
 			expect(message).toBe(
 				"Port 31415 is already in use (127.0.0.1). Stop the process using it, or change the port in settings.",
 			);
+		});
+	});
+
+	describe("durable log persistence", () => {
+		it("writes stdout/stderr chunks to a vault log file", async () => {
+			const vaultPath = await fs.mkdtemp(path.join(os.tmpdir(), "ailss-mcp-log-"));
+
+			try {
+				const { controller } = createController({ vaultPath });
+				const internals = asInternals(controller);
+				internals.resetStartupState();
+
+				internals.appendDurableLogChunk("stdout", "service ready\n");
+				internals.appendDurableLogChunk("stderr", "decode failure\n");
+				await internals.durableLogWriteQueue;
+
+				const logPath = path.join(vaultPath, ".ailss", "ailss-mcp-http-last.log");
+				const content = await fs.readFile(logPath, "utf8");
+				expect(content).toContain("[event] mcp-http-service-start");
+				expect(content).toContain("[stream] stdout");
+				expect(content).toContain("service ready");
+				expect(content).toContain("[stream] stderr");
+				expect(content).toContain("decode failure");
+			} finally {
+				await fs.rm(vaultPath, { recursive: true, force: true });
+			}
 		});
 	});
 });


### PR DESCRIPTION
## What

- Normalize MCP HTTP handling for decoder compatibility on tool-call paths.
  - Accept trailing-slash MCP endpoint paths (`/mcp/`).
  - Return JSON-RPC errors for MCP unauthorized, malformed JSON, shutdown (503), and internal failures.
- Persist Obsidian MCP service `stdout`/`stderr` to a durable vault log file at `.ailss/ailss-mcp-http-last.log`.
- Add regression tests for both MCP route behavior and plugin log durability.

## Why

- Repeated Codex MCP tool calls intermittently failed with `error decoding response body` even while the service stayed alive.
- Inconsistent MCP error payload handling and volatile in-memory logs weakened decoder safety and post-mortem diagnostics.

- Fixes #109

## How

- `packages/mcp/src/httpServerRoutes.ts`
  - Path normalization (`/mcp` and `/mcp/` treated consistently)
  - JSON-RPC error responses for MCP unauthorized/bad-request/shutdown/internal error paths
- `packages/mcp/test/httpSessions.sessionLifecycle.test.ts`
  - Added trailing-slash + malformed-JSON regression coverage
- `packages/mcp/test/httpTestUtils.ts`
  - Added JSON-RPC error assertions for unauthorized and malformed initialization requests
- `packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts`
  - Added queued durable log writes for MCP runtime stdout/stderr
  - Added durable log file hint to unexpected-stop error message
- `packages/obsidian-plugin/test/mcp/mcpHttpServiceController.startupHelpers.test.ts`
  - Added vault log persistence unit test
- Validation
  - `pnpm check` via pre-push hook (format/lint/typecheck/tests) passed
