### PR TITLE
feat: automate release tag creation on labeled merges to main

### DIFF
--- a/.github/workflows/auto-tag-on-merge.yml
+++ b/.github/workflows/auto-tag-on-merge.yml
@@ -1,0 +1,103 @@
+name: auto-tag-on-merge
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'release-on-merge')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout merged commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Compute and validate release version
+        id: meta
+        shell: bash
+        run: |
+          version="$(node <<'NODE'
+          const fs = require("fs");
+          const read = (path) => JSON.parse(fs.readFileSync(path, "utf8"));
+          const version = read("packages/core/package.json").version;
+
+          if (!version) {
+            console.error("packages/core/package.json version missing");
+            process.exit(1);
+          }
+
+          const pkgPaths = [
+            "packages/mcp/package.json",
+            "packages/indexer/package.json",
+            "packages/obsidian-plugin/package.json",
+            "packages/obsidian-plugin/manifest.json",
+          ];
+
+          for (const path of pkgPaths) {
+            const value = read(path).version;
+            if (value !== version) {
+              console.error(`version mismatch: ${path} ${value} != ${version}`);
+              process.exit(1);
+            }
+          }
+
+          const versions = read("packages/obsidian-plugin/versions.json");
+          if (!Object.prototype.hasOwnProperty.call(versions, version)) {
+            console.error(`versions.json missing key: ${version}`);
+            process.exit(1);
+          }
+
+          process.stdout.write(version);
+          NODE
+          )"
+
+          if [[ -z "${version}" ]]; then
+            echo "resolved version is empty" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create and push tag
+        env:
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          RELEASE_TAG_TOKEN: ${{ secrets.RELEASE_TAG_TOKEN }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        shell: bash
+        run: |
+          if [[ -z "${RELEASE_TAG_TOKEN}" ]]; then
+            echo "RELEASE_TAG_TOKEN is not configured" >&2
+            exit 1
+          fi
+
+          tag="v${VERSION}"
+          git fetch origin --tags
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" > /dev/null 2>&1; then
+            echo "tag already exists: ${tag}; skip"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git tag "${tag}" "${MERGE_SHA}"
+          git push "https://x-access-token:${RELEASE_TAG_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${tag}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ This repo enforces Conventional Commits (commitlint + Lefthook).
   - Default: use the existing template at `.github/pull_request_template.md` and replace all `[REPLACE ME]` placeholders.
   - Exception (version bump only): use this exact minimal format:
     - `Version bump only (service + plugin).`
-    - `- After merge: tag v<version> on main to trigger release.`
+    - `- Before merge: add label release-on-merge so v<version> is auto-tagged on merge to main.`
 - Language: PR title and body must be written in English.
 - Sections (template-based PRs only): for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).
 - Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).


### PR DESCRIPTION
## What

- Add `.github/workflows/auto-tag-on-merge.yml` to auto-create a `v<version>` tag when a labeled PR is merged into `main`
- Validate monorepo/plugin version consistency before tagging
- Skip safely when the same tag already exists

## Why

- Remove manual post-merge tagging step from release flow

- Fixes #66

## How

- Trigger on `pull_request_target` `closed` events, gated by merged PR + `main` base + `release-on-merge` label
- Resolve release version from package metadata and verify consistency
- Push tag for merge commit SHA using `RELEASE_TAG_TOKEN`
