### PR TITLE
refactor: extract shared mcp write-tool execution and frontmatter identity helpers

### DIFF
--- a/packages/mcp/src/lib/frontmatterIdentity.ts
+++ b/packages/mcp/src/lib/frontmatterIdentity.ts
@@ -1,0 +1,41 @@
+// Shared frontmatter identity helpers
+
+export function hasFrontmatterBlock(markdown: string): boolean {
+  const normalized = (markdown ?? "").replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---\n")) return false;
+  const endIdx = normalized.indexOf("\n---\n", 4);
+  const endDotsIdx = normalized.indexOf("\n...\n", 4);
+  return endIdx >= 0 || endDotsIdx >= 0;
+}
+
+export function idFromCreated(created: string): string | null {
+  const trimmed = created.trim();
+  if (!trimmed) return null;
+
+  // ISO prefix parsing
+  const iso = trimmed.length >= 19 ? trimmed.slice(0, 19) : trimmed;
+  const normalized = iso.replace(/ /g, "T");
+  const digits = normalized.replace(/[-:T]/g, "");
+  if (digits.length < 14) return null;
+  return digits.slice(0, 14);
+}
+
+export function coerceTrimmedStringOrEmpty(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : "";
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (value instanceof Date) return value.toISOString();
+  return null;
+}
+
+export function coerceNonEmptyString(value: unknown): string | null {
+  if (value instanceof Date) {
+    if (!Number.isFinite(value.getTime())) return null;
+    return value.toISOString().slice(0, 19);
+  }
+  const coerced = coerceTrimmedStringOrEmpty(value);
+  if (coerced === null || coerced === "") return null;
+  return coerced;
+}

--- a/packages/mcp/src/lib/writeToolExecution.ts
+++ b/packages/mcp/src/lib/writeToolExecution.ts
@@ -1,0 +1,86 @@
+// Shared write-tool execution helpers
+
+import type { McpToolDeps, WriteLock } from "../mcpDeps.js";
+import { reindexVaultPaths } from "./reindexVaultPaths.js";
+
+type ReindexSummary = {
+  changed_files: number;
+  indexed_chunks: number;
+  deleted_files: number;
+};
+
+export type ApplyAndOptionalReindexResult = {
+  applied: boolean;
+  needs_reindex: boolean;
+  reindexed: boolean;
+  reindex_summary: ReindexSummary | null;
+  reindex_error: string | null;
+};
+
+function errorToMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function runWithOptionalWriteLock<T>(options: {
+  apply: boolean;
+  writeLock: WriteLock | undefined;
+  run: () => Promise<T>;
+}): Promise<T> {
+  if (!options.apply) return await options.run();
+  return await (options.writeLock ? options.writeLock.runExclusive(options.run) : options.run());
+}
+
+export async function applyAndOptionalReindex(options: {
+  deps: McpToolDeps;
+  apply: boolean;
+  changed: boolean;
+  reindexAfterApply: boolean;
+  reindexPaths: string[];
+  applyWrite: () => Promise<void>;
+}): Promise<ApplyAndOptionalReindexResult> {
+  const applied = Boolean(options.apply && options.changed);
+  if (!applied) {
+    return {
+      applied: false,
+      needs_reindex: false,
+      reindexed: false,
+      reindex_summary: null,
+      reindex_error: null,
+    };
+  }
+
+  await options.applyWrite();
+
+  if (!options.reindexAfterApply) {
+    return {
+      applied: true,
+      needs_reindex: true,
+      reindexed: false,
+      reindex_summary: null,
+      reindex_error: null,
+    };
+  }
+
+  try {
+    const summary = await reindexVaultPaths(options.deps, options.reindexPaths);
+    return {
+      applied: true,
+      needs_reindex: false,
+      reindexed: true,
+      reindex_summary: {
+        changed_files: summary.changedFiles,
+        indexed_chunks: summary.indexedChunks,
+        deleted_files: summary.deletedFiles,
+      },
+      reindex_error: null,
+    };
+  } catch (error) {
+    return {
+      applied: true,
+      needs_reindex: true,
+      reindexed: false,
+      reindex_summary: null,
+      reindex_error: errorToMessage(error),
+    };
+  }
+}

--- a/packages/mcp/src/tools/canonicalizeTypedLinks.ts
+++ b/packages/mcp/src/tools/canonicalizeTypedLinks.ts
@@ -15,8 +15,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import type { McpToolDeps } from "../mcpDeps.js";
-import { reindexVaultPaths } from "../lib/reindexVaultPaths.js";
 import { readVaultFileFullText, writeVaultFileText } from "../lib/vaultFs.js";
+import { applyAndOptionalReindex, runWithOptionalWriteLock } from "../lib/writeToolExecution.js";
 
 type ReplacementEdit = {
   rel: string;
@@ -403,46 +403,30 @@ export function registerCanonicalizeTypedLinksTool(server: McpServer, deps: McpT
         const afterSha256 = sha256HexUtf8(afterText);
         const changed = afterSha256 !== beforeSha256;
 
-        let reindexed = false;
-        let reindexSummary: {
-          changed_files: number;
-          indexed_chunks: number;
-          deleted_files: number;
-        } | null = null;
-        let reindexError: string | null = null;
-
-        if (args.apply && changed) {
-          await writeVaultFileText({ vaultPath, vaultRelPath: args.path, text: afterText });
-
-          if (args.reindex_after_apply) {
-            try {
-              const summary = await reindexVaultPaths(deps, [args.path]);
-              reindexed = true;
-              reindexSummary = {
-                changed_files: summary.changedFiles,
-                indexed_chunks: summary.indexedChunks,
-                deleted_files: summary.deletedFiles,
-              };
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error);
-              reindexError = message;
-            }
-          }
-        }
+        const reindexState = await applyAndOptionalReindex({
+          deps,
+          apply: args.apply,
+          changed,
+          reindexAfterApply: args.reindex_after_apply,
+          reindexPaths: [args.path],
+          applyWrite: async () => {
+            await writeVaultFileText({ vaultPath, vaultRelPath: args.path, text: afterText });
+          },
+        });
 
         const payload = {
           path: args.path,
-          applied: Boolean(args.apply && changed),
+          applied: reindexState.applied,
           changed,
           before_sha256: beforeSha256,
           after_sha256: afterSha256,
           edits,
           unresolved,
           ambiguous,
-          needs_reindex: Boolean(args.apply && changed && !reindexed),
-          reindexed,
-          reindex_summary: reindexSummary,
-          reindex_error: reindexError,
+          needs_reindex: reindexState.needs_reindex,
+          reindexed: reindexState.reindexed,
+          reindex_summary: reindexState.reindex_summary,
+          reindex_error: reindexState.reindex_error,
         };
 
         return {
@@ -451,11 +435,7 @@ export function registerCanonicalizeTypedLinksTool(server: McpServer, deps: McpT
         };
       };
 
-      if (args.apply) {
-        return await (deps.writeLock ? deps.writeLock.runExclusive(run) : run());
-      }
-
-      return await run();
+      return await runWithOptionalWriteLock({ apply: args.apply, writeLock: deps.writeLock, run });
     },
   );
 }


### PR DESCRIPTION
## What

- Extract shared MCP write-tool execution helpers in `packages/mcp/src/lib/writeToolExecution.ts` and apply them to `canonicalize_typed_links`, `improve_frontmatter`, `edit_note`, `capture_note`, and `relocate_note`.
- Extract shared frontmatter identity helpers in `packages/mcp/src/lib/frontmatterIdentity.ts` and remove duplicated implementations from `improveFrontmatter` and `frontmatterValidate`.
- Keep tool output contracts unchanged while reducing duplicated apply/reindex/report and write-lock code paths.

## Why

- Reduce maintenance risk and behavior drift across write tools by centralizing the apply/reindex and write-lock flow.
- Remove duplicated frontmatter identity logic so fixes and updates happen in a single place.
- Fixes #117

## How

- Replace per-tool reindex/apply blocks with `applyAndOptionalReindex(...)` and per-tool lock wrappers with `runWithOptionalWriteLock(...)`.
- Add regression assertions in `packages/mcp/test/httpTools.writeTools.test.ts` for `applied`, `needs_reindex`, `reindexed`, and `reindex_error` across all affected write tools.
- Validate with `pnpm -C packages/mcp build`, `pnpm exec vitest run packages/mcp/test/httpTools.writeTools.test.ts packages/mcp/test/httpTools.frontmatterValidate.test.ts packages/mcp/test/httpTools.frontmatterValidateEdge.test.ts packages/mcp/test/httpSessions.writeLock.test.ts`, and full `pnpm check` (pre-push hook).
