### PR TITLE
feat: split release note policy for beta vs stable tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,48 @@ jobs:
 
           ls -la "${out}"
 
+      - name: Resolve previous stable tag
+        id: stable_tag
+        if: steps.meta.outputs.prerelease == 'false'
+        shell: bash
+        run: |
+          current="${GITHUB_REF_NAME}"
+          previous="$(
+            git tag --list 'v*' --sort=-v:refname \
+              | grep -Ev -- '-' \
+              | grep -Fxv -- "${current}" \
+              | head -n 1 || true
+          )"
+
+          echo "previous=${previous}" >> "${GITHUB_OUTPUT}"
+
+      - name: Generate stable release notes
+        id: stable_notes
+        if: steps.meta.outputs.prerelease == 'false'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const tagName = process.env.GITHUB_REF_NAME;
+            const previousTag = `${{ steps.stable_tag.outputs.previous }}`.trim();
+            const params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              configuration_file_path: ".github/release.yml",
+            };
+
+            if (previousTag) {
+              params.previous_tag_name = previousTag;
+            }
+
+            const response = await github.request(
+              "POST /repos/{owner}/{repo}/releases/generate-notes",
+              params
+            );
+
+            core.setOutput("body", response.data.body);
+
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,12 +196,20 @@ jobs:
         shell: bash
         run: |
           current="${GITHUB_REF_NAME}"
-          previous="$(
+          current_commit="$(git rev-list -n 1 "${current}")"
+          previous=""
+
+          while IFS= read -r tag; do
+            tag_commit="$(git rev-list -n 1 "${tag}")"
+            if git merge-base --is-ancestor "${tag_commit}" "${current_commit}"; then
+              previous="${tag}"
+              break
+            fi
+          done < <(
             git tag --list 'v*' --sort=-v:refname \
               | grep -Ev -- '-' \
-              | grep -Fxv -- "${current}" \
-              | head -n 1 || true
-          )"
+              | grep -Fxv -- "${current}"
+          )
 
           echo "previous=${previous}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,6 +237,7 @@ jobs:
         with:
           name: ${{ steps.meta.outputs.version }}
           prerelease: ${{ steps.meta.outputs.prerelease }}
-          generate_release_notes: true
+          generate_release_notes: false
+          body: ${{ steps.meta.outputs.prerelease == 'true' && 'Pre-release build' || steps.stable_notes.outputs.body }}
           files: |
             ailss-${{ steps.meta.outputs.version }}.zip


### PR DESCRIPTION
## What

- Split release note generation policy by tag type in `.github/workflows/release.yml`.
- For prerelease tags (hyphen suffix), publish release assets with a fixed body: `Pre-release build`.
- For stable tags, generate notes from the previous stable tag and keep category grouping via `.github/release.yml`.

## Why

- Prerelease tags should stay lightweight and avoid full auto-generated notes.
- Stable release notes should include all merged changes since the last stable release, even if shipped through betas.

- Fixes #104

## How

- Added a `Resolve previous stable tag` step that finds the latest `v*` tag without a hyphen, excluding the current tag.
- Added a `Generate stable release notes` step using `actions/github-script` and GitHub's `releases/generate-notes` API with `previous_tag_name` and `configuration_file_path`.
- Switched release publishing to `generate_release_notes: false` and set `body` conditionally:
  - prerelease -> `Pre-release build`
  - stable -> generated note body output
