### PR TITLE
feat: auto-apply type labels from pr title prefixes

### DIFF
--- a/.github/workflows/pr-title-type-labeler.yml
+++ b/.github/workflows/pr-title-type-labeler.yml
@@ -1,0 +1,64 @@
+name: pr-title-type-labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  apply-type-label:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Apply type label from PR title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request?.title ?? '';
+            const normalizedTitle = title.trim().toLowerCase();
+            const prefixToLabel = [
+              ['feat:', 'enhancement'],
+              ['fix:', 'bug'],
+              ['docs:', 'docs'],
+              ['refactor:', 'refactor'],
+              ['test:', 'test'],
+            ];
+
+            const matchedRule = prefixToLabel.find(([prefix]) => normalizedTitle.startsWith(prefix));
+            if (!matchedRule) {
+              core.info(`No supported title prefix found for PR #${context.issue.number}`);
+              return;
+            }
+
+            const [, mappedLabel] = matchedRule;
+            const typeLabels = new Set(prefixToLabel.map(([, label]) => label));
+            const currentLabels = (context.payload.pull_request?.labels ?? []).map((label) => label.name);
+
+            if (currentLabels.includes(mappedLabel)) {
+              core.info(`Label "${mappedLabel}" already exists on PR #${context.issue.number}`);
+              return;
+            }
+
+            const existingTypeLabel = currentLabels.find((label) => typeLabels.has(label));
+            if (existingTypeLabel) {
+              core.info(
+                `Type label "${existingTypeLabel}" already exists on PR #${context.issue.number}; skipping to avoid overriding manual labels`,
+              );
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [mappedLabel],
+            });
+
+            core.info(`Applied "${mappedLabel}" from title prefix "${matchedRule[0]}"`);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,9 @@ This repo enforces Conventional Commits (commitlint + Lefthook).
   - Exception (version bump only): use this exact minimal format:
     - `Version bump only (service + plugin).`
     - `- Before merge: add label release-on-merge so v<version> is auto-tagged on merge to main.`
+  - Labels (version bump only):
+    - Add `ignore-for-release` so the bump PR is excluded from auto-generated release notes.
+    - Add `release-on-merge` before merging to `main` to trigger auto-tagging.
 - Language: PR title and body must be written in English.
 - Sections (template-based PRs only): for each template section (`## What`, `## Why`, `## How`), write content as bullet points only (no prose paragraphs).
 - Scope: the PR description must reflect _all_ changes in the branch (code + docs + tests).
@@ -128,10 +131,13 @@ When filing an issue, optimize for fast, high-confidence triage.
 - Proposed solution (optional): if you have a hypothesis or fix direction, add it as a separate bullet list.
 - Security: if the issue involves secrets or an exploitable vulnerability, do **not** file a public issue; report privately.
 
-### 2.10 GitHub labels (area labeler)
+### 2.10 GitHub labels (area + type labeler)
 
 - Area labels (`plugin`, `mcp`, `indexer`, `core`, `docs`, `ops`) are auto-applied by the GitHub Actions labeler based on changed file paths.
   - Config: `.github/workflows/labeler.yml` + `.github/labeler.yml`
+- Type labels are auto-applied from PR title prefixes (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`) via `.github/workflows/pr-title-type-labeler.yml`.
+  - Mapping: `feat` → `enhancement`, `fix` → `bug`, `docs` → `docs`, `refactor` → `refactor`, `test` → `test`
+  - The workflow only adds a missing mapped type label and skips when a type label already exists.
 - Manually apply labels that are not path-derived (for example: `ignore-for-release`).
 
 ---

--- a/packages/obsidian-plugin/AGENTS.md
+++ b/packages/obsidian-plugin/AGENTS.md
@@ -32,7 +32,7 @@ This directory contains the **Obsidian community plugin** for AILSS.
     - Log snapshot file export: `packages/obsidian-plugin/src/indexer/indexerLogFile.ts`
 - MCP HTTP service: `packages/obsidian-plugin/src/mcp/*`
     - Lifecycle: `packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts`
-    - Search wrapper: `packages/obsidian-plugin/src/mcp/semanticSearchService.ts`
+    - Shared types: `packages/obsidian-plugin/src/mcp/mcpHttpServiceTypes.ts`
 - UI helpers (keep `main.ts` thin): `packages/obsidian-plugin/src/ui/*`
     - Modal open helpers: `packages/obsidian-plugin/src/ui/pluginModals.ts`
     - Status bar mounting/rendering: `packages/obsidian-plugin/src/ui/statusBars.ts`


### PR DESCRIPTION
## What

- Add a workflow that auto-applies a type label from PR title prefixes.
- Keep existing path-based area labeling unchanged.

## Why

- Type labels are currently not auto-applied from PR title prefixes.
- Fixes #100

## How

- Add `.github/workflows/pr-title-type-labeler.yml` with `pull_request_target` triggers on `opened`, `edited`, and `synchronize`.
- Map `feat:`, `fix:`, `docs:`, `refactor:`, and `test:` to `enhancement`, `bug`, `docs`, `refactor`, and `test`.
- Add only when the mapped label is missing, and skip when another mapped type label already exists to avoid overriding manual labels.
