### PR TITLE
feat: add structured HTTP boundary diagnostics for MCP early returns

### DIFF
--- a/packages/mcp/src/httpServerRoutes.ts
+++ b/packages/mcp/src/httpServerRoutes.ts
@@ -31,6 +31,82 @@ const SESSION_NOT_FOUND_RECOVERY_DATA: JsonRpcErrorData = {
   retryRequest: true,
 };
 
+type HttpBoundaryEarlyReturnReason =
+  | "shutdown_unauthorized"
+  | "path_not_found"
+  | "mcp_unauthorized"
+  | "invalid_json_body"
+  | "multiple_session_id_headers"
+  | "missing_session_id_header"
+  | "session_not_found"
+  | "not_acceptable";
+
+type HttpBoundaryDiagnosticEvent = {
+  event: "mcp_http_boundary_early_return";
+  timestamp: string;
+  status: 400 | 401 | 404 | 406;
+  request_id: string | number | null;
+  method: string;
+  path: string;
+  accept: string | null;
+  has_mcp_session_id: boolean;
+  reason: HttpBoundaryEarlyReturnReason;
+};
+
+function extractRequestId(body: unknown): string | number | null {
+  if (Array.isArray(body)) {
+    for (const entry of body) {
+      const requestId = extractRequestId(entry);
+      if (requestId !== null) return requestId;
+    }
+    return null;
+  }
+
+  if (typeof body !== "object" || body === null) return null;
+
+  const id = (body as Record<string, unknown>)["id"];
+  if (typeof id === "string") return id;
+  if (typeof id === "number" && Number.isFinite(id)) return id;
+  return null;
+}
+
+function getAcceptHeader(req: IncomingMessage): string | null {
+  const accept = getSingleHeaderValue(req, "accept");
+  if (typeof accept === "string") return accept;
+  if (accept === "multiple") {
+    const raw = req.headers.accept;
+    if (Array.isArray(raw)) return raw.join(", ");
+    return "multiple";
+  }
+  return null;
+}
+
+function hasMcpSessionId(req: IncomingMessage): boolean {
+  return getSingleHeaderValue(req, "mcp-session-id") !== null;
+}
+
+function logHttpBoundaryEarlyReturnDiagnostic(options: {
+  req: IncomingMessage;
+  requestPath: string;
+  status: 400 | 401 | 404 | 406;
+  requestId: string | number | null;
+  reason: HttpBoundaryEarlyReturnReason;
+}): void {
+  const event: HttpBoundaryDiagnosticEvent = {
+    event: "mcp_http_boundary_early_return",
+    timestamp: new Date().toISOString(),
+    status: options.status,
+    request_id: options.requestId,
+    method: options.req.method ?? "UNKNOWN",
+    path: options.requestPath,
+    accept: getAcceptHeader(options.req),
+    has_mcp_session_id: hasMcpSessionId(options.req),
+    reason: options.reason,
+  };
+
+  console.warn(JSON.stringify(event));
+}
+
 function trimTrailingSlash(pathname: string): string {
   if (pathname.length > 1 && pathname.endsWith("/")) return pathname.slice(0, -1);
   return pathname;
@@ -88,6 +164,13 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
 
         const token = extractBearerToken(req, url);
         if (token !== options.shutdown.token) {
+          logHttpBoundaryEarlyReturnDiagnostic({
+            req,
+            requestPath,
+            status: 401,
+            requestId: null,
+            reason: "shutdown_unauthorized",
+          });
           sendText(res, 401, "unauthorized");
           return;
         }
@@ -117,22 +200,45 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
       }
 
       if (requestPath !== configPath) {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 404,
+          requestId: null,
+          reason: "path_not_found",
+        });
         sendText(res, 404, "not found");
         return;
       }
 
       const token = extractBearerToken(req, url);
       if (token !== options.config.token) {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 401,
+          requestId: null,
+          reason: "mcp_unauthorized",
+        });
         sendJsonRpcError(res, 401, -32000, "Unauthorized");
         return;
       }
 
       let parsedBody: unknown = undefined;
+      let requestId: string | number | null = null;
       if (req.method === "POST") {
         try {
           parsedBody = await readJsonBody(req, 1_000_000);
+          requestId = extractRequestId(parsedBody);
         } catch (error) {
           const message = error instanceof Error ? error.message : "Bad request.";
+          logHttpBoundaryEarlyReturnDiagnostic({
+            req,
+            requestPath,
+            status: 400,
+            requestId: null,
+            reason: "invalid_json_body",
+          });
           sendJsonRpcError(res, 400, -32000, `Bad Request: ${message}`);
           return;
         }
@@ -146,6 +252,15 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
           res,
           parsedBody,
         );
+        if (res.statusCode === 406) {
+          logHttpBoundaryEarlyReturnDiagnostic({
+            req,
+            requestPath,
+            status: 406,
+            requestId,
+            reason: "not_acceptable",
+          });
+        }
 
         if (transport.sessionId === undefined) {
           await transport.close();
@@ -157,6 +272,13 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
 
       const sessionIdHeader = getSingleHeaderValue(req, "mcp-session-id");
       if (sessionIdHeader === "multiple") {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 400,
+          requestId,
+          reason: "multiple_session_id_headers",
+        });
         sendJsonRpcError(
           res,
           400,
@@ -166,12 +288,26 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
         return;
       }
       if (!sessionIdHeader) {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 400,
+          requestId,
+          reason: "missing_session_id_header",
+        });
         sendJsonRpcError(res, 400, -32000, "Bad Request: Mcp-Session-Id header is required");
         return;
       }
 
       const session = options.sessionStore.touchSession(sessionIdHeader);
       if (!session) {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 404,
+          requestId,
+          reason: "session_not_found",
+        });
         sendJsonRpcError(res, 404, -32001, "Session not found", SESSION_NOT_FOUND_RECOVERY_DATA);
         return;
       }
@@ -182,6 +318,15 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
         res,
         parsedBody,
       );
+      if (res.statusCode === 406) {
+        logHttpBoundaryEarlyReturnDiagnostic({
+          req,
+          requestPath,
+          status: 406,
+          requestId,
+          reason: "not_acceptable",
+        });
+      }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
 

--- a/packages/mcp/test/httpBoundaryDiagnostics.test.ts
+++ b/packages/mcp/test/httpBoundaryDiagnostics.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+import path from "node:path";
+
+import {
+  mcpInitializeExpectBadRequest,
+  mcpInitializeExpectUnauthorized,
+  mcpToolsListExpectBadRequest,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+const MCP_PROTOCOL_VERSION = "2025-03-26";
+
+type BoundaryEvent = {
+  event: string;
+  status: number;
+  request_id: string | number | null;
+  method: string;
+  path: string;
+  accept: string | null;
+  has_mcp_session_id: boolean;
+  reason: string;
+};
+
+describe("MCP HTTP server (boundary diagnostics)", () => {
+  it("emits structured diagnostics for 400/401/404/406 early returns", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      let events: BoundaryEvent[] = [];
+
+      try {
+        await withMcpHttpServer({ dbPath }, async ({ url, token }) => {
+          await mcpInitializeExpectUnauthorized(url, "wrong-token");
+          await mcpInitializeExpectBadRequest(url, token);
+          await mcpToolsListExpectBadRequest(url, token);
+
+          const missingPathUrl = new URL(url);
+          missingPathUrl.pathname = "/missing-path";
+          const missingPathResponse = await fetch(missingPathUrl.toString());
+          expect(missingPathResponse.status).toBe(404);
+          await missingPathResponse.text();
+
+          const notAcceptableResponse = await fetch(url, {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+              Accept: "text/plain",
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 99,
+              method: "initialize",
+              params: {
+                protocolVersion: MCP_PROTOCOL_VERSION,
+                capabilities: {},
+                clientInfo: { name: "diag-client", version: "0" },
+              },
+            }),
+          });
+          expect(notAcceptableResponse.status).toBe(406);
+          await notAcceptableResponse.text();
+        });
+        events = parseBoundaryEvents(warnSpy);
+      } finally {
+        warnSpy.mockRestore();
+      }
+
+      expect(events.length).toBeGreaterThanOrEqual(5);
+
+      const unauthorized = findByReason(events, "mcp_unauthorized");
+      expect(unauthorized.status).toBe(401);
+      expect(unauthorized.request_id).toBe(null);
+      expect(unauthorized.has_mcp_session_id).toBe(false);
+      expect(unauthorized.path).toBe("/mcp");
+
+      const invalidJson = findByReason(events, "invalid_json_body");
+      expect(invalidJson.status).toBe(400);
+      expect(invalidJson.request_id).toBe(null);
+
+      const missingSessionId = findByReason(events, "missing_session_id_header");
+      expect(missingSessionId.status).toBe(400);
+      expect(missingSessionId.request_id).toBe(2);
+      expect(missingSessionId.has_mcp_session_id).toBe(false);
+
+      const pathNotFound = findByReason(events, "path_not_found");
+      expect(pathNotFound.status).toBe(404);
+      expect(pathNotFound.path).toBe("/missing-path");
+
+      const notAcceptable = findByReason(events, "not_acceptable");
+      expect(notAcceptable.status).toBe(406);
+      expect(notAcceptable.request_id).toBe(99);
+      expect(notAcceptable.accept).toBe("text/plain");
+
+      for (const event of events) {
+        expect(event.event).toBe("mcp_http_boundary_early_return");
+        expect(typeof event.method).toBe("string");
+        expect(typeof event.path).toBe("string");
+        expect(typeof event.reason).toBe("string");
+        expect(typeof event.has_mcp_session_id).toBe("boolean");
+      }
+    });
+  });
+});
+
+function parseBoundaryEvents(warnSpy: ReturnType<typeof vi.spyOn>): BoundaryEvent[] {
+  return warnSpy.mock.calls
+    .map((call) => call[0])
+    .filter((line): line is string => typeof line === "string")
+    .map((line) => {
+      try {
+        return JSON.parse(line) as unknown;
+      } catch {
+        return null;
+      }
+    })
+    .filter((value): value is BoundaryEvent => {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+      if ((value as Record<string, unknown>)["event"] !== "mcp_http_boundary_early_return") {
+        return false;
+      }
+      return true;
+    });
+}
+
+function findByReason(events: BoundaryEvent[], reason: string): BoundaryEvent {
+  const match = events.find((event) => event.reason === reason);
+  if (!match) {
+    throw new Error(`Missing boundary diagnostic event for reason=${reason}`);
+  }
+  return match;
+}

--- a/packages/mcp/test/httpBoundaryDiagnostics.test.ts
+++ b/packages/mcp/test/httpBoundaryDiagnostics.test.ts
@@ -105,18 +105,18 @@ describe("MCP HTTP server (boundary diagnostics)", () => {
   });
 });
 
-function parseBoundaryEvents(warnSpy: ReturnType<typeof vi.spyOn>): BoundaryEvent[] {
+function parseBoundaryEvents(warnSpy: { mock: { calls: unknown[][] } }): BoundaryEvent[] {
   return warnSpy.mock.calls
-    .map((call) => call[0])
-    .filter((line): line is string => typeof line === "string")
-    .map((line) => {
+    .map((call: unknown[]) => call[0])
+    .filter((line: unknown): line is string => typeof line === "string")
+    .map((line: string) => {
       try {
         return JSON.parse(line) as unknown;
       } catch {
         return null;
       }
     })
-    .filter((value): value is BoundaryEvent => {
+    .filter((value: unknown): value is BoundaryEvent => {
       if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
       if ((value as Record<string, unknown>)["event"] !== "mcp_http_boundary_early_return") {
         return false;


### PR DESCRIPTION
## What
- Added structured boundary diagnostics logging for MCP HTTP early returns in `packages/mcp/src/httpServerRoutes.ts`.
- Covered status codes 400/401/404 direct early-return paths and 406 not-acceptable responses coming from transport handling.
- Added a focused integration test for required diagnostic fields and reason mappings.

## Why
- Improve observability at the HTTP boundary before tool execution so transport/protocol failures can be separated quickly from tool-level failures.
- Fixes #111

## How
- Introduced a JSON-line diagnostic event (`mcp_http_boundary_early_return`) with fields: `request_id`, `method`, `path`, `accept`, `has_mcp_session_id`, and `reason`.
- Logged reason-coded diagnostics at each 400/401/404 early-return branch.
- Logged 406 diagnostics immediately after transport handling when content negotiation rejects the request.
- Added `packages/mcp/test/httpBoundaryDiagnostics.test.ts` to validate status coverage and field contract.
