### PR TITLE
fix: default MCP Streamable HTTP POST responses to JSON

### DIFF
--- a/packages/mcp/src/httpServer.ts
+++ b/packages/mcp/src/httpServer.ts
@@ -6,6 +6,7 @@ import http from "node:http";
 import { createAilssMcpRuntimeFromEnv } from "./createAilssMcpServer.js";
 import {
   normalizeShutdownConfig,
+  parseEnableJsonResponseFromEnv,
   parseHttpConfigFromEnv,
   parseIdleTtlMsFromEnv,
   parseMaxSessionsFromEnv,
@@ -29,6 +30,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
 
   const maxSessions = options.maxSessions ?? parseMaxSessionsFromEnv();
   const idleTtlMs = options.idleTtlMs ?? parseIdleTtlMsFromEnv();
+  const enableJsonResponse = options.enableJsonResponse ?? parseEnableJsonResponseFromEnv();
   const shutdown = normalizeShutdownConfig(options.shutdown);
   const sessionStore = new McpSessionStore(maxSessions, idleTtlMs);
 
@@ -43,6 +45,7 @@ export async function startAilssMcpHttpServer(options: StartHttpServerOptions): 
     config,
     runtime,
     sessionStore,
+    enableJsonResponse,
     shutdown,
     isShuttingDown: () => shuttingDown,
     startShuttingDown,

--- a/packages/mcp/src/httpServerConfig.ts
+++ b/packages/mcp/src/httpServerConfig.ts
@@ -12,6 +12,7 @@ export type StartHttpServerOptions = {
   config: HttpConfig;
   maxSessions?: number;
   idleTtlMs?: number;
+  enableJsonResponse?: boolean;
   shutdown?: {
     path?: string;
     token: string;
@@ -67,6 +68,17 @@ export function parseIdleTtlMsFromEnv(): number {
   const n = Number.parseInt(raw, 10);
   if (!Number.isFinite(n) || n < 0) return 3_600_000;
   return n;
+}
+
+export function parseEnableJsonResponseFromEnv(): boolean {
+  const raw = (process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE ?? "1").trim().toLowerCase();
+  if (!raw) return true;
+
+  if (raw === "1" || raw === "true" || raw === "yes" || raw === "on") return true;
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") return false;
+
+  // Invalid values: fall back to the default (true).
+  return true;
 }
 
 export function normalizeShutdownConfig(

--- a/packages/mcp/src/httpServerConfig.ts
+++ b/packages/mcp/src/httpServerConfig.ts
@@ -71,14 +71,16 @@ export function parseIdleTtlMsFromEnv(): number {
 }
 
 export function parseEnableJsonResponseFromEnv(): boolean {
-  const raw = (process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE ?? "1").trim().toLowerCase();
+  const rawValue = (process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE ?? "1").trim();
+  const raw = rawValue.toLowerCase();
   if (!raw) return true;
 
   if (raw === "1" || raw === "true" || raw === "yes" || raw === "on") return true;
   if (raw === "0" || raw === "false" || raw === "no" || raw === "off") return false;
 
-  // Invalid values: fall back to the default (true).
-  return true;
+  throw new Error(
+    `Invalid AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE: "${rawValue}". Expected 0/1/true/false/on/off/yes/no.`,
+  );
 }
 
 export function normalizeShutdownConfig(

--- a/packages/mcp/src/httpServerRoutes.ts
+++ b/packages/mcp/src/httpServerRoutes.ts
@@ -17,6 +17,7 @@ type CreateHttpRequestHandlerOptions = {
   config: HttpConfig;
   runtime: AilssMcpRuntime;
   sessionStore: McpSessionStore;
+  enableJsonResponse: boolean;
   shutdown: ShutdownConfig | null;
   isShuttingDown: () => boolean;
   startShuttingDown: () => void;
@@ -140,7 +141,11 @@ export function createHttpRequestHandler(options: CreateHttpRequestHandlerOption
 
       if (req.method === "POST" && isInitializeRequestMessage(parsedBody)) {
         options.sessionStore.closeIdleSessions();
-        const { server, transport } = await createSession(options.runtime, options.sessionStore);
+        const { server, transport } = await createSession(
+          options.runtime,
+          options.sessionStore,
+          options.enableJsonResponse,
+        );
         await transport.handleRequest(
           req as IncomingMessage & { auth?: AuthInfo },
           res,

--- a/packages/mcp/src/httpServerSessions.ts
+++ b/packages/mcp/src/httpServerSessions.ts
@@ -92,10 +92,12 @@ export class McpSessionStore {
 export async function createSession(
   runtime: AilssMcpRuntime,
   sessionStore: McpSessionStore,
+  enableJsonResponse: boolean,
 ): Promise<{ server: McpServer; transport: StreamableHTTPServerTransport }> {
   const { server } = createAilssMcpServerFromRuntime(runtime);
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
+    enableJsonResponse,
     onsessioninitialized: (sessionId) => {
       sessionStore.initializeSession(sessionId, server, transport);
     },

--- a/packages/mcp/test/docs.mcpToolingConsistency.test.ts
+++ b/packages/mcp/test/docs.mcpToolingConsistency.test.ts
@@ -7,7 +7,7 @@ import {
   assertArray,
   assertRecord,
   mcpInitialize,
-  parseFirstSseData,
+  parseFirstMcpPayload,
   withMcpHttpServer,
   withTempDir,
 } from "./httpTestUtils.js";
@@ -41,7 +41,7 @@ async function mcpToolsList(
   });
 
   expect(res.status).toBe(200);
-  const payload = parseFirstSseData(await res.text());
+  const payload = parseFirstMcpPayload(await res.text());
 
   assertRecord(payload, "tools/list payload");
   const result = payload["result"];

--- a/packages/mcp/test/httpServerConfig.unit.test.ts
+++ b/packages/mcp/test/httpServerConfig.unit.test.ts
@@ -131,7 +131,9 @@ describe("httpServerConfig helpers", () => {
     expect(parseEnableJsonResponseFromEnv()).toBe(true);
 
     process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "weird";
-    expect(parseEnableJsonResponseFromEnv()).toBe(true);
+    expect(() => parseEnableJsonResponseFromEnv()).toThrow(
+      'Invalid AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE: "weird". Expected 0/1/true/false/on/off/yes/no.',
+    );
   });
 
   it("normalizes shutdown config", () => {

--- a/packages/mcp/test/httpServerConfig.unit.test.ts
+++ b/packages/mcp/test/httpServerConfig.unit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 import {
   normalizeShutdownConfig,
+  parseEnableJsonResponseFromEnv,
   parseHttpConfigFromEnv,
   parseIdleTtlMsFromEnv,
   parseMaxSessionsFromEnv,
@@ -15,7 +16,8 @@ type HttpEnvKey =
   | "AILSS_MCP_HTTP_TOKEN"
   | "AILSS_MCP_TOKEN"
   | "AILSS_MCP_HTTP_MAX_SESSIONS"
-  | "AILSS_MCP_HTTP_IDLE_TTL_MS";
+  | "AILSS_MCP_HTTP_IDLE_TTL_MS"
+  | "AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE";
 
 const HTTP_ENV_KEYS: HttpEnvKey[] = [
   "AILSS_MCP_HTTP_HOST",
@@ -25,6 +27,7 @@ const HTTP_ENV_KEYS: HttpEnvKey[] = [
   "AILSS_MCP_TOKEN",
   "AILSS_MCP_HTTP_MAX_SESSIONS",
   "AILSS_MCP_HTTP_IDLE_TTL_MS",
+  "AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE",
 ];
 
 const originalEnv: Partial<Record<HttpEnvKey, string | undefined>> = {};
@@ -109,6 +112,26 @@ describe("httpServerConfig helpers", () => {
     process.env.AILSS_MCP_HTTP_IDLE_TTL_MS = "2500";
     expect(parseMaxSessionsFromEnv()).toBe(12);
     expect(parseIdleTtlMsFromEnv()).toBe(2500);
+  });
+
+  it("parses JSON response toggle with safe defaults", () => {
+    delete process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE;
+    expect(parseEnableJsonResponseFromEnv()).toBe(true);
+
+    process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "";
+    expect(parseEnableJsonResponseFromEnv()).toBe(true);
+
+    process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "0";
+    expect(parseEnableJsonResponseFromEnv()).toBe(false);
+
+    process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "false";
+    expect(parseEnableJsonResponseFromEnv()).toBe(false);
+
+    process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "1";
+    expect(parseEnableJsonResponseFromEnv()).toBe(true);
+
+    process.env.AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE = "weird";
+    expect(parseEnableJsonResponseFromEnv()).toBe(true);
   });
 
   it("normalizes shutdown config", () => {

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -17,7 +17,8 @@ type EnvKey =
   | "AILSS_DB_PATH"
   | "AILSS_VAULT_PATH"
   | "AILSS_ENABLE_WRITE_TOOLS"
-  | "AILSS_MCP_HTTP_MAX_SESSIONS";
+  | "AILSS_MCP_HTTP_MAX_SESSIONS"
+  | "AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE";
 
 export type EnvOverrides = Partial<Record<EnvKey, string | undefined>>;
 
@@ -59,6 +60,7 @@ export type McpHttpServerTestOptions = {
   dbPath?: string;
   vaultPath?: string;
   enableWriteTools?: boolean;
+  enableJsonResponseEnv?: string;
   token?: string;
   shutdownToken?: string;
   maxSessions?: number;
@@ -67,7 +69,10 @@ export type McpHttpServerTestOptions = {
 };
 
 function envForMcpRuntime(
-  options: Pick<McpHttpServerTestOptions, "dbPath" | "vaultPath" | "enableWriteTools">,
+  options: Pick<
+    McpHttpServerTestOptions,
+    "dbPath" | "vaultPath" | "enableWriteTools" | "enableJsonResponseEnv"
+  >,
 ) {
   if (options.dbPath && options.vaultPath) {
     throw new Error("Test misconfiguration: provide only one of dbPath or vaultPath");
@@ -85,6 +90,7 @@ function envForMcpRuntime(
     AILSS_DB_PATH: "",
     AILSS_VAULT_PATH: "",
     AILSS_ENABLE_WRITE_TOOLS: "",
+    AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE: options.enableJsonResponseEnv ?? "1",
   };
 
   if (options.dbPath) {
@@ -137,7 +143,7 @@ export async function withMcpHttpServer<T>(
   });
 }
 
-export function parseFirstSseData(body: string): unknown {
+export function parseFirstMcpPayload(body: string): unknown {
   const normalized = (body ?? "").trim();
   if (!normalized) {
     throw new Error("Expected response body to be non-empty");
@@ -165,6 +171,9 @@ export function parseFirstSseData(body: string): unknown {
     );
   }
 }
+
+// Backwards-compatible alias (historically SSE-only).
+export const parseFirstSseData = parseFirstMcpPayload;
 
 export function assertRecord(
   value: unknown,
@@ -371,7 +380,7 @@ export async function mcpToolsCall(
   });
 
   expect(res.status).toBe(200);
-  return parseFirstSseData(await res.text());
+  return parseFirstMcpPayload(await res.text());
 }
 
 export async function mcpToolsList(url: string, token: string, sessionId: string): Promise<void> {
@@ -393,7 +402,7 @@ export async function mcpToolsList(url: string, token: string, sessionId: string
   });
 
   expect(res.status).toBe(200);
-  const payload = parseFirstSseData(await res.text());
+  const payload = parseFirstMcpPayload(await res.text());
 
   assertRecord(payload, "tools/list payload");
   expect(payload).toHaveProperty("result.tools");

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -138,12 +138,32 @@ export async function withMcpHttpServer<T>(
 }
 
 export function parseFirstSseData(body: string): unknown {
-  const dataLine = body
+  const normalized = (body ?? "").trim();
+  if (!normalized) {
+    throw new Error("Expected response body to be non-empty");
+  }
+
+  // SSE mode: `text/event-stream` with `data: { ... }`
+  const dataLine = normalized
     .split("\n")
     .map((l) => l.trim())
     .find((l) => l.startsWith("data: "));
-  expect(dataLine).toBeTruthy();
-  return JSON.parse((dataLine as string).slice("data: ".length)) as unknown;
+  if (dataLine) {
+    return JSON.parse(dataLine.slice("data: ".length)) as unknown;
+  }
+
+  // JSON response mode: `application/json` with a plain JSON-RPC payload.
+  try {
+    return JSON.parse(normalized) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to parse MCP response body as SSE or JSON: ${message}. Body: ${normalized.slice(
+        0,
+        500,
+      )}`,
+    );
+  }
 }
 
 export function assertRecord(

--- a/packages/mcp/test/httpTransport.responseFormat.test.ts
+++ b/packages/mcp/test/httpTransport.responseFormat.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import path from "node:path";
+
+import {
+  assertRecord,
+  parseFirstMcpPayload,
+  withMcpHttpServer,
+  withTempDir,
+} from "./httpTestUtils.js";
+
+const MCP_PROTOCOL_VERSION = "2025-03-26" as const;
+
+async function mcpInitializeRaw(options: {
+  url: string;
+  token: string;
+  clientName: string;
+  accept: string;
+}): Promise<{
+  status: number;
+  contentType: string;
+  sessionId: string | null;
+  body: string;
+  payload: unknown;
+}> {
+  const res = await fetch(options.url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${options.token}`,
+      Accept: options.accept,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: options.clientName, version: "0" },
+      },
+    }),
+  });
+
+  const status = res.status;
+  const contentType = res.headers.get("content-type") ?? "";
+  const sessionId = res.headers.get("mcp-session-id");
+
+  const body = await res.text();
+  const payload = parseFirstMcpPayload(body);
+  return { status, contentType, sessionId, body, payload };
+}
+
+describe("MCP HTTP server (Streamable HTTP response format)", () => {
+  it("returns JSON by default when client accepts JSON", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const res = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-json",
+          accept: "application/json, text/event-stream",
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.contentType.startsWith("application/json")).toBe(true);
+        expect(res.sessionId).toBeTruthy();
+        assertRecord(res.payload, "initialize payload");
+        expect(res.payload).toHaveProperty("result");
+      });
+    });
+  });
+
+  it("rejects clients that do not accept both application/json and text/event-stream", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const res = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-sse-only",
+          accept: "text/event-stream",
+        });
+
+        expect(res.status).toBe(406);
+        expect(res.sessionId).toBeFalsy();
+        assertRecord(res.payload, "error payload");
+        expect(res.payload).toHaveProperty("error.message");
+      });
+    });
+  });
+
+  it("forces SSE when AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE=0", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer(
+        { dbPath, enableWriteTools: false, enableJsonResponseEnv: "0" },
+        async ({ url, token }) => {
+          const res = await mcpInitializeRaw({
+            url,
+            token,
+            clientName: "client-forced-sse",
+            accept: "application/json, text/event-stream",
+          });
+
+          expect(res.status).toBe(200);
+          expect(res.contentType.startsWith("text/event-stream")).toBe(true);
+          expect(res.sessionId).toBeTruthy();
+          assertRecord(res.payload, "initialize payload");
+          expect(res.payload).toHaveProperty("result");
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## What

- Default MCP Streamable HTTP POST responses to `application/json`.
- Add `AILSS_MCP_HTTP_ENABLE_JSON_RESPONSE` (default: `1`) to roll back to SSE when needed.

## Why

- Some Streamable HTTP clients intermittently fail decoding `text/event-stream` bodies as JSON (`error decoding response body`).
- Fixes #131

## How

- Propagate `enableJsonResponse` from options/env into `StreamableHTTPServerTransport` session creation.
- Make HTTP test helpers accept both SSE and JSON response modes.

## Validation

- `pnpm check`