### PR TITLE
fix: enforce frontmatter enum values for status/layer/entity

### DIFF
--- a/docs/standards/vault/frontmatter-schema.md
+++ b/docs/standards/vault/frontmatter-schema.md
@@ -11,7 +11,7 @@ created: "{{date:YYYY-MM-DDTHH:mm:ss}}"
 title: {{title}}
 summary:
 aliases:
-# concept | document | project | artifact | person | organization | place | event | task | method | tool | idea | principle | heuristic | pattern | definition | question | software | dataset | pipeline | procedure | dashboard | checklist | workflow | decide | review | plan | implement | approve | reject | observe | measure | test | verify | learn | research | summarize | publish | meet | audit | deploy | rollback | refactor | design | delete | update | create | schedule | migrate | reference | hub
+# interface | concept | document | project | artifact | person | organization | place | event | task | method | tool | idea | principle | heuristic | pattern | definition | question | software | dataset | pipeline | procedure | dashboard | checklist | workflow | decide | review | plan | implement | approve | reject | observe | measure | test | verify | learn | research | analyze | summarize | publish | meet | audit | deploy | rollback | refactor | design | delete | update | create | schedule | migrate | reference | hub | guide | log | structure | architecture
 entity:
 # strategic | conceptual | logical | physical | operational
 # why / what / structure / implementation / operations

--- a/packages/core/src/vault/frontmatter.ts
+++ b/packages/core/src/vault/frontmatter.ts
@@ -13,6 +13,176 @@ export type TypedLink = {
   position: number;
 };
 
+// Frontmatter enums
+// - keep in sync with docs/standards/vault/frontmatter-schema.md
+export const AILSS_FRONTMATTER_STATUS_VALUES = [
+  "draft",
+  "in-review",
+  "active",
+  "archived",
+] as const;
+export type AilssFrontmatterStatus = (typeof AILSS_FRONTMATTER_STATUS_VALUES)[number];
+
+export const AILSS_FRONTMATTER_LAYER_VALUES = [
+  "strategic",
+  "conceptual",
+  "logical",
+  "physical",
+  "operational",
+] as const;
+export type AilssFrontmatterLayer = (typeof AILSS_FRONTMATTER_LAYER_VALUES)[number];
+
+export const AILSS_FRONTMATTER_ENTITY_VALUES = [
+  // Interface entities
+  "interface",
+  "pipeline",
+  "procedure",
+  "dashboard",
+  "checklist",
+  "workflow",
+
+  // Action entities
+  "decide",
+  "review",
+  "plan",
+  "implement",
+  "approve",
+  "reject",
+  "observe",
+  "measure",
+  "test",
+  "verify",
+  "learn",
+  "research",
+  "summarize",
+  "publish",
+  "meet",
+  "audit",
+  "deploy",
+  "rollback",
+  "refactor",
+  "design",
+  "delete",
+  "update",
+  "create",
+  "schedule",
+  "migrate",
+  "analyze",
+
+  // Object entities
+  "concept",
+  "document",
+  "project",
+  "artifact",
+  "person",
+  "organization",
+  "place",
+  "event",
+  "task",
+  "method",
+  "tool",
+  "idea",
+  "principle",
+  "heuristic",
+  "pattern",
+  "definition",
+  "question",
+  "software",
+  "dataset",
+  "reference",
+  "hub",
+  "guide",
+  "log",
+  "structure",
+  "architecture",
+] as const;
+export type AilssFrontmatterEntity = (typeof AILSS_FRONTMATTER_ENTITY_VALUES)[number];
+
+const AILSS_FRONTMATTER_STATUS_SET = new Set<string>(AILSS_FRONTMATTER_STATUS_VALUES);
+const AILSS_FRONTMATTER_LAYER_SET = new Set<string>(AILSS_FRONTMATTER_LAYER_VALUES);
+const AILSS_FRONTMATTER_ENTITY_SET = new Set<string>(AILSS_FRONTMATTER_ENTITY_VALUES);
+
+export function isAilssFrontmatterStatus(value: string): value is AilssFrontmatterStatus {
+  return AILSS_FRONTMATTER_STATUS_SET.has(value);
+}
+
+export function isAilssFrontmatterLayer(value: string): value is AilssFrontmatterLayer {
+  return AILSS_FRONTMATTER_LAYER_SET.has(value);
+}
+
+export function isAilssFrontmatterEntity(value: string): value is AilssFrontmatterEntity {
+  return AILSS_FRONTMATTER_ENTITY_SET.has(value);
+}
+
+export type AilssFrontmatterEnumViolation = {
+  key: "status" | "layer" | "entity";
+  value: string | null;
+  allowed: readonly string[];
+};
+
+export function validateAilssFrontmatterEnums(
+  frontmatter: Record<string, unknown>,
+): AilssFrontmatterEnumViolation[] {
+  const violations: AilssFrontmatterEnumViolation[] = [];
+  const hasOwn = (key: string) => Object.prototype.hasOwnProperty.call(frontmatter, key);
+  const describeValue = (value: unknown): string | null => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "string") return value.trim();
+    if (typeof value === "number" && Number.isFinite(value)) return String(value);
+    if (value instanceof Date && Number.isFinite(value.getTime()))
+      return value.toISOString().slice(0, 19);
+    try {
+      const json = JSON.stringify(value);
+      if (typeof json === "string") return json;
+    } catch {
+      // ignore
+    }
+    return String(value);
+  };
+
+  if (hasOwn("status")) {
+    const value = frontmatter.status;
+    const raw = coerceString(value);
+    if (!raw || !isAilssFrontmatterStatus(raw)) {
+      violations.push({
+        key: "status",
+        value: describeValue(value),
+        allowed: AILSS_FRONTMATTER_STATUS_VALUES,
+      });
+    }
+  }
+
+  if (hasOwn("layer")) {
+    const value = frontmatter.layer;
+    const raw = coerceString(value);
+    const isUnset =
+      value === null || value === undefined || (typeof value === "string" && !value.trim());
+    if (!isUnset && (!raw || !isAilssFrontmatterLayer(raw))) {
+      violations.push({
+        key: "layer",
+        value: describeValue(value),
+        allowed: AILSS_FRONTMATTER_LAYER_VALUES,
+      });
+    }
+  }
+
+  if (hasOwn("entity")) {
+    const value = frontmatter.entity;
+    const raw = coerceString(value);
+    const isUnset =
+      value === null || value === undefined || (typeof value === "string" && !value.trim());
+    if (!isUnset && (!raw || !isAilssFrontmatterEntity(raw))) {
+      violations.push({
+        key: "entity",
+        value: describeValue(value),
+        allowed: AILSS_FRONTMATTER_ENTITY_VALUES,
+      });
+    }
+  }
+
+  return violations;
+}
+
 export type NormalizedAilssNoteMeta = {
   noteId: string | null;
   created: string | null;

--- a/packages/mcp/src/lib/frontmatterValidate/scanVaultNotes.ts
+++ b/packages/mcp/src/lib/frontmatterValidate/scanVaultNotes.ts
@@ -1,0 +1,148 @@
+import {
+  listMarkdownFiles,
+  normalizeAilssNoteMeta,
+  parseMarkdownNote,
+  validateAilssFrontmatterEnums,
+} from "@ailss/core";
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  coerceTrimmedStringOrEmpty,
+  hasFrontmatterBlock,
+  idFromCreated,
+} from "../frontmatterIdentity.js";
+
+import type { ScannedNote, TargetLookupNote } from "./types.js";
+
+function relPathFromAbs(vaultPath: string, absPath: string): string {
+  return path.relative(vaultPath, absPath).split(path.sep).join(path.posix.sep);
+}
+
+function normalizeEntity(value: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+export async function scanVaultNotesForFrontmatterValidate(options: {
+  vaultPath: string;
+  pathPrefix: string | null;
+  maxFiles: number;
+  requiredKeys: readonly string[];
+}): Promise<{
+  scannedNotes: ScannedNote[];
+  targetLookupNotes: TargetLookupNote[];
+  filesScanned: number;
+  truncated: boolean;
+}> {
+  const prefix = options.pathPrefix ? options.pathPrefix.trim() : null;
+  const absFiles = await listMarkdownFiles(options.vaultPath);
+  const relFiles = absFiles.map((abs) => relPathFromAbs(options.vaultPath, abs));
+  const filtered = prefix ? relFiles.filter((p) => p.startsWith(prefix)) : relFiles;
+
+  const scannedNotes: ScannedNote[] = [];
+
+  let filesScanned = 0;
+  let truncated = false;
+
+  for (const relPath of filtered) {
+    if (filesScanned >= options.maxFiles) {
+      truncated = true;
+      break;
+    }
+
+    const absPath = path.join(options.vaultPath, relPath);
+    filesScanned += 1;
+
+    const markdown = await fs.readFile(absPath, "utf8");
+    const hasFm = hasFrontmatterBlock(markdown);
+    const parsed = parseMarkdownNote(markdown);
+    const fm = parsed.frontmatter ?? {};
+    const normalizedMeta = normalizeAilssNoteMeta(fm);
+
+    const missing: string[] = [];
+    for (const key of options.requiredKeys) {
+      if (!Object.prototype.hasOwnProperty.call(fm, key)) missing.push(key);
+    }
+
+    const enumViolations = validateAilssFrontmatterEnums(fm).map((violation) => ({
+      key: violation.key,
+      value: violation.value,
+    }));
+
+    const idRaw = coerceTrimmedStringOrEmpty((fm as Record<string, unknown>).id);
+    const createdRaw = coerceTrimmedStringOrEmpty((fm as Record<string, unknown>).created);
+    const createdId = createdRaw ? idFromCreated(createdRaw) : null;
+
+    const idValue = idRaw;
+    const createdValue = createdRaw;
+
+    const idFormatOk = typeof idValue === "string" && /^\d{14}$/.test(idValue);
+    const createdFormatOk = typeof createdId === "string" && /^\d{14}$/.test(createdId);
+    const idMatchesCreated = Boolean(idFormatOk && createdFormatOk && idValue === createdId);
+
+    // Frontmatter parse status
+    const parsedFrontmatter = hasFm && Object.keys(fm).length > 0;
+    scannedNotes.push({
+      path: relPath,
+      has_frontmatter: hasFm,
+      parsed_frontmatter: parsedFrontmatter,
+      missing_keys: missing,
+      enum_violations: enumViolations,
+      id_value: idValue,
+      created_value: createdValue,
+      id_format_ok: idFormatOk,
+      created_format_ok: createdFormatOk,
+      id_matches_created: idMatchesCreated,
+      note_id: normalizedMeta.noteId,
+      title: normalizedMeta.title,
+      entity: normalizeEntity(normalizedMeta.entity),
+      typed_links: normalizedMeta.typedLinks.map((link) => ({
+        rel: link.rel,
+        to_target: link.toTarget,
+        to_wikilink: link.toWikilink,
+        position: link.position,
+      })),
+    });
+  }
+
+  let targetLookupNotes: TargetLookupNote[] = scannedNotes.map((note) => ({
+    path: note.path,
+    parsed_frontmatter: note.parsed_frontmatter,
+    note_id: note.note_id,
+    title: note.title,
+    entity: note.entity,
+  }));
+
+  // Prefix scan policy
+  // - source-note set is limited by path_prefix/max_files
+  // - target resolution uses vault-wide metadata for better relation validation accuracy
+  if (prefix) {
+    const scannedPathSet = new Set(scannedNotes.map((note) => note.path));
+    const additionalLookupNotes: TargetLookupNote[] = [];
+
+    for (const relPath of relFiles) {
+      if (scannedPathSet.has(relPath)) continue;
+      const absPath = path.join(options.vaultPath, relPath);
+      const markdown = await fs.readFile(absPath, "utf8");
+      const hasFm = hasFrontmatterBlock(markdown);
+      const parsed = parseMarkdownNote(markdown);
+      const fm = parsed.frontmatter ?? {};
+      const normalizedMeta = normalizeAilssNoteMeta(fm);
+
+      additionalLookupNotes.push({
+        path: relPath,
+        parsed_frontmatter: hasFm && Object.keys(fm).length > 0,
+        note_id: normalizedMeta.noteId,
+        title: normalizedMeta.title,
+        entity: normalizeEntity(normalizedMeta.entity),
+      });
+    }
+
+    targetLookupNotes = [...targetLookupNotes, ...additionalLookupNotes];
+  }
+
+  return { scannedNotes, targetLookupNotes, filesScanned, truncated };
+}

--- a/packages/mcp/src/lib/frontmatterValidate/typedLinkDiagnostics.ts
+++ b/packages/mcp/src/lib/frontmatterValidate/typedLinkDiagnostics.ts
@@ -1,0 +1,184 @@
+import { AILSS_TYPED_LINK_ONTOLOGY_BY_REL } from "@ailss/core";
+
+import type { ScannedNote, TargetLookupNote, TypedLinkDiagnostic } from "./types.js";
+
+function normalizeEntity(value: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized ? normalized : null;
+}
+
+function normalizeValueForLookup(value: string | null): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized ? normalized : null;
+}
+
+export function collectTypedLinkDiagnostics(
+  notes: ScannedNote[],
+  lookupNotes: TargetLookupNote[],
+  mode: "warn" | "error",
+): TypedLinkDiagnostic[] {
+  const noteIdIndex = new Map<string, TargetLookupNote[]>();
+  const titleIndex = new Map<string, TargetLookupNote[]>();
+
+  const parseableNotes = notes.filter((note) => note.parsed_frontmatter);
+  const parseableLookupNotes = lookupNotes.filter((note) => note.parsed_frontmatter);
+
+  for (const note of parseableLookupNotes) {
+    const noteId = normalizeValueForLookup(note.note_id);
+    if (noteId) {
+      const existing = noteIdIndex.get(noteId) ?? [];
+      existing.push(note);
+      noteIdIndex.set(noteId, existing);
+    }
+
+    const title = normalizeValueForLookup(note.title);
+    if (title) {
+      const existing = titleIndex.get(title) ?? [];
+      existing.push(note);
+      titleIndex.set(title, existing);
+    }
+  }
+
+  const resolveTargetEntity = (
+    target: string,
+  ): { status: "unresolved" | "ambiguous" | "resolved"; entity: string | null } => {
+    const trimmed = target.trim();
+    if (!trimmed) return { status: "unresolved", entity: null };
+
+    const targetNoExt = trimmed.toLowerCase().endsWith(".md") ? trimmed.slice(0, -3) : trimmed;
+    const targetWithExt = trimmed.toLowerCase().endsWith(".md") ? trimmed : `${trimmed}.md`;
+
+    const matches: TargetLookupNote[] = [];
+    const seenPaths = new Set<string>();
+    const addMatch = (candidate: TargetLookupNote): void => {
+      if (seenPaths.has(candidate.path)) return;
+      seenPaths.add(candidate.path);
+      matches.push(candidate);
+    };
+
+    for (const note of parseableLookupNotes) {
+      if (note.path === targetWithExt || note.path.endsWith(`/${targetWithExt}`)) addMatch(note);
+    }
+
+    for (const note of noteIdIndex.get(targetNoExt) ?? []) addMatch(note);
+    for (const note of titleIndex.get(targetNoExt) ?? []) addMatch(note);
+
+    if (matches.length === 0) return { status: "unresolved", entity: null };
+    if (matches.length >= 2) return { status: "ambiguous", entity: null };
+    return { status: "resolved", entity: normalizeEntity(matches[0]?.entity ?? null) };
+  };
+
+  const severity: "warn" | "error" = mode === "error" ? "error" : "warn";
+  const diagnostics: TypedLinkDiagnostic[] = [];
+  const seenDiagnostics = new Set<string>();
+  const pushDiagnostic = (diag: TypedLinkDiagnostic): void => {
+    const key = `${diag.path}\u0000${diag.rel}\u0000${diag.target ?? ""}\u0000${diag.reason}`;
+    if (seenDiagnostics.has(key)) return;
+    seenDiagnostics.add(key);
+    diagnostics.push(diag);
+  };
+
+  for (const note of parseableNotes) {
+    if (note.typed_links.length === 0) continue;
+
+    const sourceEntity = normalizeEntity(note.entity);
+    const targetsByRel = new Map<string, Set<string>>();
+
+    for (const link of note.typed_links) {
+      const rel = link.rel.trim();
+      if (!rel) continue;
+      const target = link.to_target.trim();
+      const targets = targetsByRel.get(rel) ?? new Set<string>();
+      if (target) targets.add(target);
+      targetsByRel.set(rel, targets);
+    }
+
+    for (const [rel, targets] of targetsByRel) {
+      const ontology =
+        AILSS_TYPED_LINK_ONTOLOGY_BY_REL[rel as keyof typeof AILSS_TYPED_LINK_ONTOLOGY_BY_REL];
+      const constraints = ontology && "constraints" in ontology ? ontology.constraints : undefined;
+      if (!constraints) continue;
+
+      if (typeof constraints.maxTargets === "number" && targets.size > constraints.maxTargets) {
+        pushDiagnostic({
+          path: note.path,
+          rel,
+          target: null,
+          reason: `cardinality exceeded: ${targets.size} targets (max ${constraints.maxTargets})`,
+          fix_hint: `Keep at most ${constraints.maxTargets} target(s) for \`${rel}\`.`,
+          severity,
+        });
+      }
+
+      if (constraints.sourceEntities?.length && sourceEntity) {
+        const allowedSourceEntities = constraints.sourceEntities.map((entity: string) =>
+          entity.toLowerCase(),
+        );
+        if (!allowedSourceEntities.includes(sourceEntity)) {
+          pushDiagnostic({
+            path: note.path,
+            rel,
+            target: null,
+            reason: `source entity "${sourceEntity}" is incompatible with relation "${rel}"`,
+            fix_hint: `Use one of: ${constraints.sourceEntities.join(", ")}, or move this link to a compatible note.`,
+            severity,
+          });
+        }
+      }
+
+      if (constraints.conflictsWith?.length) {
+        for (const conflictRel of constraints.conflictsWith) {
+          const conflictTargets = targetsByRel.get(conflictRel) ?? new Set<string>();
+          for (const target of targets) {
+            if (!conflictTargets.has(target)) continue;
+            pushDiagnostic({
+              path: note.path,
+              rel,
+              target,
+              reason: `conflict: same target appears in both "${rel}" and "${conflictRel}"`,
+              fix_hint: `Keep "${target}" in only one of the two relations.`,
+              severity,
+            });
+          }
+        }
+      }
+    }
+
+    for (const link of note.typed_links) {
+      const rel = link.rel.trim();
+      if (!rel) continue;
+
+      const target = link.to_target.trim();
+      if (!target) continue;
+
+      const ontology =
+        AILSS_TYPED_LINK_ONTOLOGY_BY_REL[rel as keyof typeof AILSS_TYPED_LINK_ONTOLOGY_BY_REL];
+      const constraints = ontology && "constraints" in ontology ? ontology.constraints : undefined;
+      if (!constraints?.targetEntities || constraints.targetEntities.length === 0) continue;
+
+      const resolved = resolveTargetEntity(target);
+      if (resolved.status !== "resolved") continue;
+
+      const targetEntity = normalizeEntity(resolved.entity);
+      if (!targetEntity) continue;
+
+      const allowedTargetEntities = constraints.targetEntities.map((entity: string) =>
+        entity.toLowerCase(),
+      );
+      if (allowedTargetEntities.includes(targetEntity)) continue;
+
+      pushDiagnostic({
+        path: note.path,
+        rel,
+        target,
+        reason: `target entity "${targetEntity}" is incompatible with relation "${rel}"`,
+        fix_hint: `Point \`${rel}\` to one of: ${constraints.targetEntities.join(", ")}.`,
+        severity,
+      });
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/mcp/src/lib/frontmatterValidate/types.ts
+++ b/packages/mcp/src/lib/frontmatterValidate/types.ts
@@ -1,0 +1,42 @@
+export type TypedLinkRecord = {
+  rel: string;
+  to_target: string;
+  to_wikilink: string;
+  position: number;
+};
+
+export type FrontmatterEnumViolation = {
+  key: "status" | "layer" | "entity";
+  value: string | null;
+};
+
+export type ScannedNote = {
+  path: string;
+  has_frontmatter: boolean;
+  parsed_frontmatter: boolean;
+  missing_keys: string[];
+  enum_violations: FrontmatterEnumViolation[];
+  id_value: string | null;
+  created_value: string | null;
+  id_format_ok: boolean;
+  created_format_ok: boolean;
+  id_matches_created: boolean;
+  note_id: string | null;
+  title: string | null;
+  entity: string | null;
+  typed_links: TypedLinkRecord[];
+};
+
+export type TargetLookupNote = Pick<
+  ScannedNote,
+  "path" | "parsed_frontmatter" | "note_id" | "title" | "entity"
+>;
+
+export type TypedLinkDiagnostic = {
+  path: string;
+  rel: string;
+  target: string | null;
+  reason: string;
+  fix_hint: string;
+  severity: "warn" | "error";
+};

--- a/packages/mcp/src/tools/frontmatterValidate.ts
+++ b/packages/mcp/src/tools/frontmatterValidate.ts
@@ -5,24 +5,14 @@ import {
   AILSS_FRONTMATTER_ENTITY_VALUES,
   AILSS_FRONTMATTER_LAYER_VALUES,
   AILSS_FRONTMATTER_STATUS_VALUES,
-  AILSS_TYPED_LINK_ONTOLOGY_BY_REL,
-  listMarkdownFiles,
-  normalizeAilssNoteMeta,
-  parseMarkdownNote,
-  validateAilssFrontmatterEnums,
 } from "@ailss/core";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
-import { promises as fs } from "node:fs";
-import path from "node:path";
-
 import type { McpToolDeps } from "../mcpDeps.js";
-import {
-  coerceTrimmedStringOrEmpty,
-  hasFrontmatterBlock,
-  idFromCreated,
-} from "../lib/frontmatterIdentity.js";
+import { scanVaultNotesForFrontmatterValidate } from "../lib/frontmatterValidate/scanVaultNotes.js";
+import type { TypedLinkDiagnostic } from "../lib/frontmatterValidate/types.js";
+import { collectTypedLinkDiagnostics } from "../lib/frontmatterValidate/typedLinkDiagnostics.js";
 
 const REQUIRED_KEYS = [
   "id",
@@ -40,230 +30,6 @@ const REQUIRED_KEYS = [
 ] as const;
 
 const TYPED_LINK_CONSTRAINT_MODES = ["off", "warn", "error"] as const;
-type TypedLinkConstraintMode = (typeof TYPED_LINK_CONSTRAINT_MODES)[number];
-
-type TypedLinkRecord = {
-  rel: string;
-  to_target: string;
-  to_wikilink: string;
-  position: number;
-};
-
-type ScannedNote = {
-  path: string;
-  has_frontmatter: boolean;
-  parsed_frontmatter: boolean;
-  missing_keys: string[];
-  enum_violations: Array<{ key: "status" | "layer" | "entity"; value: string | null }>;
-  id_value: string | null;
-  created_value: string | null;
-  id_format_ok: boolean;
-  created_format_ok: boolean;
-  id_matches_created: boolean;
-  note_id: string | null;
-  title: string | null;
-  entity: string | null;
-  typed_links: TypedLinkRecord[];
-};
-
-type TargetLookupNote = Pick<
-  ScannedNote,
-  "path" | "parsed_frontmatter" | "note_id" | "title" | "entity"
->;
-
-type TypedLinkDiagnostic = {
-  path: string;
-  rel: string;
-  target: string | null;
-  reason: string;
-  fix_hint: string;
-  severity: "warn" | "error";
-};
-
-function relPathFromAbs(vaultPath: string, absPath: string): string {
-  return path.relative(vaultPath, absPath).split(path.sep).join(path.posix.sep);
-}
-
-function normalizeEntity(value: string | null): string | null {
-  if (typeof value !== "string") return null;
-  const normalized = value.trim().toLowerCase();
-  return normalized ? normalized : null;
-}
-
-function normalizeValueForLookup(value: string | null): string | null {
-  if (typeof value !== "string") return null;
-  const normalized = value.trim();
-  return normalized ? normalized : null;
-}
-
-function collectTypedLinkDiagnostics(
-  notes: ScannedNote[],
-  lookupNotes: TargetLookupNote[],
-  mode: Exclude<TypedLinkConstraintMode, "off">,
-): TypedLinkDiagnostic[] {
-  const noteIdIndex = new Map<string, TargetLookupNote[]>();
-  const titleIndex = new Map<string, TargetLookupNote[]>();
-
-  const parseableNotes = notes.filter((note) => note.parsed_frontmatter);
-  const parseableLookupNotes = lookupNotes.filter((note) => note.parsed_frontmatter);
-
-  for (const note of parseableLookupNotes) {
-    const noteId = normalizeValueForLookup(note.note_id);
-    if (noteId) {
-      const existing = noteIdIndex.get(noteId) ?? [];
-      existing.push(note);
-      noteIdIndex.set(noteId, existing);
-    }
-
-    const title = normalizeValueForLookup(note.title);
-    if (title) {
-      const existing = titleIndex.get(title) ?? [];
-      existing.push(note);
-      titleIndex.set(title, existing);
-    }
-  }
-
-  const resolveTargetEntity = (
-    target: string,
-  ): { status: "unresolved" | "ambiguous" | "resolved"; entity: string | null } => {
-    const trimmed = target.trim();
-    if (!trimmed) return { status: "unresolved", entity: null };
-
-    const targetNoExt = trimmed.toLowerCase().endsWith(".md") ? trimmed.slice(0, -3) : trimmed;
-    const targetWithExt = trimmed.toLowerCase().endsWith(".md") ? trimmed : `${trimmed}.md`;
-
-    const matches: TargetLookupNote[] = [];
-    const seenPaths = new Set<string>();
-    const addMatch = (candidate: TargetLookupNote): void => {
-      if (seenPaths.has(candidate.path)) return;
-      seenPaths.add(candidate.path);
-      matches.push(candidate);
-    };
-
-    for (const note of parseableLookupNotes) {
-      if (note.path === targetWithExt || note.path.endsWith(`/${targetWithExt}`)) addMatch(note);
-    }
-
-    for (const note of noteIdIndex.get(targetNoExt) ?? []) addMatch(note);
-    for (const note of titleIndex.get(targetNoExt) ?? []) addMatch(note);
-
-    if (matches.length === 0) return { status: "unresolved", entity: null };
-    if (matches.length >= 2) return { status: "ambiguous", entity: null };
-    return { status: "resolved", entity: normalizeEntity(matches[0]?.entity ?? null) };
-  };
-
-  const severity: "warn" | "error" = mode === "error" ? "error" : "warn";
-  const diagnostics: TypedLinkDiagnostic[] = [];
-  const seenDiagnostics = new Set<string>();
-  const pushDiagnostic = (diag: TypedLinkDiagnostic): void => {
-    const key = `${diag.path}\u0000${diag.rel}\u0000${diag.target ?? ""}\u0000${diag.reason}`;
-    if (seenDiagnostics.has(key)) return;
-    seenDiagnostics.add(key);
-    diagnostics.push(diag);
-  };
-
-  for (const note of parseableNotes) {
-    if (note.typed_links.length === 0) continue;
-
-    const sourceEntity = normalizeEntity(note.entity);
-    const targetsByRel = new Map<string, Set<string>>();
-
-    for (const link of note.typed_links) {
-      const rel = link.rel.trim();
-      if (!rel) continue;
-      const target = link.to_target.trim();
-      const targets = targetsByRel.get(rel) ?? new Set<string>();
-      if (target) targets.add(target);
-      targetsByRel.set(rel, targets);
-    }
-
-    for (const [rel, targets] of targetsByRel) {
-      const ontology =
-        AILSS_TYPED_LINK_ONTOLOGY_BY_REL[rel as keyof typeof AILSS_TYPED_LINK_ONTOLOGY_BY_REL];
-      const constraints = ontology && "constraints" in ontology ? ontology.constraints : undefined;
-      if (!constraints) continue;
-
-      if (typeof constraints.maxTargets === "number" && targets.size > constraints.maxTargets) {
-        pushDiagnostic({
-          path: note.path,
-          rel,
-          target: null,
-          reason: `cardinality exceeded: ${targets.size} targets (max ${constraints.maxTargets})`,
-          fix_hint: `Keep at most ${constraints.maxTargets} target(s) for \`${rel}\`.`,
-          severity,
-        });
-      }
-
-      if (constraints.sourceEntities?.length && sourceEntity) {
-        const allowedSourceEntities = constraints.sourceEntities.map((entity: string) =>
-          entity.toLowerCase(),
-        );
-        if (!allowedSourceEntities.includes(sourceEntity)) {
-          pushDiagnostic({
-            path: note.path,
-            rel,
-            target: null,
-            reason: `source entity "${sourceEntity}" is incompatible with relation "${rel}"`,
-            fix_hint: `Use one of: ${constraints.sourceEntities.join(", ")}, or move this link to a compatible note.`,
-            severity,
-          });
-        }
-      }
-
-      if (constraints.conflictsWith?.length) {
-        for (const conflictRel of constraints.conflictsWith) {
-          const conflictTargets = targetsByRel.get(conflictRel) ?? new Set<string>();
-          for (const target of targets) {
-            if (!conflictTargets.has(target)) continue;
-            pushDiagnostic({
-              path: note.path,
-              rel,
-              target,
-              reason: `conflict: same target appears in both "${rel}" and "${conflictRel}"`,
-              fix_hint: `Keep "${target}" in only one of the two relations.`,
-              severity,
-            });
-          }
-        }
-      }
-    }
-
-    for (const link of note.typed_links) {
-      const rel = link.rel.trim();
-      if (!rel) continue;
-
-      const target = link.to_target.trim();
-      if (!target) continue;
-
-      const ontology =
-        AILSS_TYPED_LINK_ONTOLOGY_BY_REL[rel as keyof typeof AILSS_TYPED_LINK_ONTOLOGY_BY_REL];
-      const constraints = ontology && "constraints" in ontology ? ontology.constraints : undefined;
-      if (!constraints?.targetEntities || constraints.targetEntities.length === 0) continue;
-
-      const resolved = resolveTargetEntity(target);
-      if (resolved.status !== "resolved") continue;
-
-      const targetEntity = normalizeEntity(resolved.entity);
-      if (!targetEntity) continue;
-
-      const allowedTargetEntities = constraints.targetEntities.map((entity: string) =>
-        entity.toLowerCase(),
-      );
-      if (allowedTargetEntities.includes(targetEntity)) continue;
-
-      pushDiagnostic({
-        path: note.path,
-        rel,
-        target,
-        reason: `target entity "${targetEntity}" is incompatible with relation "${rel}"`,
-        fix_hint: `Point \`${rel}\` to one of: ${constraints.targetEntities.join(", ")}.`,
-        severity,
-      });
-    }
-  }
-
-  return diagnostics;
-}
 
 export function registerFrontmatterValidateTool(server: McpServer, deps: McpToolDeps): void {
   server.registerTool(
@@ -354,118 +120,20 @@ export function registerFrontmatterValidateTool(server: McpServer, deps: McpTool
       }
 
       const prefix = args.path_prefix ? args.path_prefix.trim() : null;
-      const absFiles = await listMarkdownFiles(vaultPath);
-      const relFiles = absFiles.map((abs) => relPathFromAbs(vaultPath, abs));
-      const filtered = prefix ? relFiles.filter((p) => p.startsWith(prefix)) : relFiles;
 
-      const scannedNotes: ScannedNote[] = [];
-
-      let filesScanned = 0;
-      let truncated = false;
-
-      for (const relPath of filtered) {
-        if (filesScanned >= args.max_files) {
-          truncated = true;
-          break;
-        }
-
-        const absPath = path.join(vaultPath, relPath);
-        filesScanned += 1;
-
-        const markdown = await fs.readFile(absPath, "utf8");
-        const hasFm = hasFrontmatterBlock(markdown);
-        const parsed = parseMarkdownNote(markdown);
-        const fm = parsed.frontmatter ?? {};
-        const normalizedMeta = normalizeAilssNoteMeta(fm);
-
-        const missing: string[] = [];
-        for (const key of REQUIRED_KEYS) {
-          if (!Object.prototype.hasOwnProperty.call(fm, key)) missing.push(key);
-        }
-
-        const enumViolations = validateAilssFrontmatterEnums(fm).map((violation) => ({
-          key: violation.key,
-          value: violation.value,
-        }));
-
-        const idRaw = coerceTrimmedStringOrEmpty((fm as Record<string, unknown>).id);
-        const createdRaw = coerceTrimmedStringOrEmpty((fm as Record<string, unknown>).created);
-        const createdId = createdRaw ? idFromCreated(createdRaw) : null;
-
-        const idValue = idRaw;
-        const createdValue = createdRaw;
-
-        const idFormatOk = typeof idValue === "string" && /^\d{14}$/.test(idValue);
-        const createdFormatOk = typeof createdId === "string" && /^\d{14}$/.test(createdId);
-        const idMatchesCreated = Boolean(idFormatOk && createdFormatOk && idValue === createdId);
-
-        // Frontmatter parse status
-        const parsedFrontmatter = hasFm && Object.keys(fm).length > 0;
-        scannedNotes.push({
-          path: relPath,
-          has_frontmatter: hasFm,
-          parsed_frontmatter: parsedFrontmatter,
-          missing_keys: missing,
-          enum_violations: enumViolations,
-          id_value: idValue,
-          created_value: createdValue,
-          id_format_ok: idFormatOk,
-          created_format_ok: createdFormatOk,
-          id_matches_created: idMatchesCreated,
-          note_id: normalizedMeta.noteId,
-          title: normalizedMeta.title,
-          entity: normalizeEntity(normalizedMeta.entity),
-          typed_links: normalizedMeta.typedLinks.map((link) => ({
-            rel: link.rel,
-            to_target: link.toTarget,
-            to_wikilink: link.toWikilink,
-            position: link.position,
-          })),
-        });
-      }
-
-      let targetLookupNotes: TargetLookupNote[] = scannedNotes.map((note) => ({
-        path: note.path,
-        parsed_frontmatter: note.parsed_frontmatter,
-        note_id: note.note_id,
-        title: note.title,
-        entity: note.entity,
-      }));
-
-      // Prefix scan policy
-      // - source-note set is limited by path_prefix/max_files
-      // - target resolution uses vault-wide metadata for better relation validation accuracy
-      if (prefix) {
-        const scannedPathSet = new Set(scannedNotes.map((note) => note.path));
-        const additionalLookupNotes: TargetLookupNote[] = [];
-
-        for (const relPath of relFiles) {
-          if (scannedPathSet.has(relPath)) continue;
-          const absPath = path.join(vaultPath, relPath);
-          const markdown = await fs.readFile(absPath, "utf8");
-          const hasFm = hasFrontmatterBlock(markdown);
-          const parsed = parseMarkdownNote(markdown);
-          const fm = parsed.frontmatter ?? {};
-          const normalizedMeta = normalizeAilssNoteMeta(fm);
-
-          additionalLookupNotes.push({
-            path: relPath,
-            parsed_frontmatter: hasFm && Object.keys(fm).length > 0,
-            note_id: normalizedMeta.noteId,
-            title: normalizedMeta.title,
-            entity: normalizeEntity(normalizedMeta.entity),
-          });
-        }
-
-        targetLookupNotes = [...targetLookupNotes, ...additionalLookupNotes];
-      }
+      const scan = await scanVaultNotesForFrontmatterValidate({
+        vaultPath,
+        pathPrefix: prefix,
+        maxFiles: args.max_files,
+        requiredKeys: REQUIRED_KEYS,
+      });
 
       const typedLinkDiagnostics =
         args.typed_link_constraint_mode === "off"
           ? []
           : collectTypedLinkDiagnostics(
-              scannedNotes,
-              targetLookupNotes,
+              scan.scannedNotes,
+              scan.targetLookupNotes,
               args.typed_link_constraint_mode,
             );
 
@@ -491,7 +159,7 @@ export function registerFrontmatterValidateTool(server: McpServer, deps: McpTool
       }> = [];
 
       let okCount = 0;
-      for (const note of scannedNotes) {
+      for (const note of scan.scannedNotes) {
         const noteDiagnostics = diagnosticsByPath.get(note.path) ?? [];
         const hasConstraintError =
           args.typed_link_constraint_mode === "error" && noteDiagnostics.length > 0;
@@ -528,10 +196,10 @@ export function registerFrontmatterValidateTool(server: McpServer, deps: McpTool
 
       const payload = {
         path_prefix: prefix,
-        files_scanned: filesScanned,
+        files_scanned: scan.filesScanned,
         ok_count: okCount,
         issue_count: issues.length,
-        truncated,
+        truncated: scan.truncated,
         enum_schema: {
           status: [...AILSS_FRONTMATTER_STATUS_VALUES],
           layer: [...AILSS_FRONTMATTER_LAYER_VALUES],


### PR DESCRIPTION
## What

- Reject invalid `status`/`layer`/`entity` overrides in `capture_note`.
- Report enum violations in `frontmatter_validate` output (`issues[].enum_violations`).

## Why

- Prevents inconsistent vault metadata (e.g. `status: evergreen`) that weakens filtering/queries.

- Fixes #132

## How

- Define canonical enum sets + shared validator in `@ailss/core`.
- Apply the shared validator in MCP write/validate tools with clear errors.
- Add regression tests for both `capture_note` and `frontmatter_validate`.
