### PR TITLE
refactor: split mcp http service controller helpers

### DIFF
--- a/packages/obsidian-plugin/src/mcp/httpService/durableLog.ts
+++ b/packages/obsidian-plugin/src/mcp/httpService/durableLog.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { nowIso } from "../../utils/misc.js";
+
+export const MCP_HTTP_LOG_DIR = ".ailss";
+export const MCP_HTTP_LOG_FILE = "ailss-mcp-http-last.log";
+
+export function enqueueDurableLogWrite(
+	queue: Promise<void>,
+	task: () => Promise<void>,
+): Promise<void> {
+	return queue.then(task).catch((error) => {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`[ailss-mcp-http] durable log write failed: ${message}`);
+	});
+}
+
+export function initializeDurableLog(options: {
+	vaultPath: string;
+	durableLogWriteQueue: Promise<void>;
+}): { durableLogPath: string | null; durableLogWriteQueue: Promise<void> } {
+	const vaultPath = options.vaultPath.trim();
+	if (!vaultPath) {
+		return {
+			durableLogPath: null,
+			durableLogWriteQueue: options.durableLogWriteQueue,
+		};
+	}
+
+	const dir = path.join(vaultPath, MCP_HTTP_LOG_DIR);
+	const filePath = path.join(dir, MCP_HTTP_LOG_FILE);
+	const header = [`[time] ${nowIso()}`, "[event] mcp-http-service-start", ""].join("\n");
+
+	return {
+		durableLogPath: filePath,
+		durableLogWriteQueue: enqueueDurableLogWrite(options.durableLogWriteQueue, async () => {
+			await fs.promises.mkdir(dir, { recursive: true });
+			await fs.promises.writeFile(filePath, header, "utf8");
+		}),
+	};
+}
+
+export function appendDurableLogChunk(options: {
+	durableLogPath: string | null;
+	durableLogWriteQueue: Promise<void>;
+	stream: "stdout" | "stderr";
+	chunk: string;
+}): { durableLogWriteQueue: Promise<void> } {
+	const filePath = options.durableLogPath;
+	if (!filePath || !options.chunk) {
+		return { durableLogWriteQueue: options.durableLogWriteQueue };
+	}
+
+	const content = options.chunk.trimEnd();
+	if (!content) {
+		return { durableLogWriteQueue: options.durableLogWriteQueue };
+	}
+
+	const entry = [`[time] ${nowIso()}`, `[stream] ${options.stream}`, content, ""].join("\n");
+	return {
+		durableLogWriteQueue: enqueueDurableLogWrite(options.durableLogWriteQueue, async () => {
+			await fs.promises.appendFile(filePath, entry, "utf8");
+		}),
+	};
+}

--- a/packages/obsidian-plugin/src/mcp/httpService/messages.ts
+++ b/packages/obsidian-plugin/src/mcp/httpService/messages.ts
@@ -1,0 +1,29 @@
+export function composePortInUseErrorMessage(options: {
+	host: string;
+	port: number;
+	shutdownAttempted: boolean;
+	shutdownSucceeded: boolean;
+	lastErrorMessage: string | null;
+}): string {
+	const baseMessage = `Port ${options.port} is already in use (${options.host}). Stop the process using it, or change the port in settings.`;
+	if (options.shutdownAttempted && !options.shutdownSucceeded && options.lastErrorMessage) {
+		return `${options.lastErrorMessage}\n\n${baseMessage}`;
+	}
+
+	return baseMessage;
+}
+
+export function composeUnexpectedStopErrorMessage(options: {
+	code: number | null;
+	signal: NodeJS.Signals | null;
+	liveStderr: string;
+	durableLogPath: string | null;
+}): string {
+	const stderr = options.liveStderr.trim();
+	const stderrTail = stderr ? stderr.split(/\r?\n/).slice(-10).join("\n").trim() : "";
+	const suffix = options.code === null ? `signal ${options.signal}` : `exit ${options.code}`;
+	const logHint = options.durableLogPath ? `\nMCP log file: ${options.durableLogPath}` : "";
+	return stderrTail
+		? `Unexpected stop (${suffix}). Last stderr:\n${stderrTail}${logHint}`
+		: `Unexpected stop (${suffix}).${logHint}`;
+}

--- a/packages/obsidian-plugin/src/mcp/httpService/preflight.ts
+++ b/packages/obsidian-plugin/src/mcp/httpService/preflight.ts
@@ -1,0 +1,87 @@
+import { type AilssObsidianSettings } from "../../settings.js";
+import { clampPort, clampTopK } from "../../utils/clamp.js";
+
+export type StartupPreflight = {
+	settings: AilssObsidianSettings;
+	host: string;
+	port: number;
+	topK: number;
+	token: string;
+	shutdownToken: string;
+	openaiApiKey: string;
+	mcpCommand: string;
+	mcpArgs: string[];
+	vaultPath: string;
+};
+
+export async function normalizeStartupSettings(options: {
+	settings: AilssObsidianSettings;
+	saveSettings: () => Promise<void>;
+}): Promise<{
+	port: number;
+	topK: number;
+}> {
+	const port = clampPort(options.settings.mcpHttpServicePort);
+	if (port !== options.settings.mcpHttpServicePort) {
+		options.settings.mcpHttpServicePort = port;
+		await options.saveSettings();
+	}
+
+	const topK = clampTopK(options.settings.topK);
+	if (topK !== options.settings.topK) {
+		options.settings.topK = topK;
+		await options.saveSettings();
+	}
+
+	return { port, topK };
+}
+
+export async function prepareStartupPreflight(options: {
+	getSettings: () => AilssObsidianSettings;
+	saveSettings: () => Promise<void>;
+	getVaultPath: () => string;
+	resolveMcpHttpArgs: () => string[];
+	normalizeStartupSettings: (
+		settings: AilssObsidianSettings,
+	) => Promise<{ port: number; topK: number }>;
+}): Promise<StartupPreflight> {
+	const settings = options.getSettings();
+	const token = settings.mcpHttpServiceToken.trim();
+	if (!token) {
+		throw new Error("Missing MCP service token.");
+	}
+
+	const shutdownToken = settings.mcpHttpServiceShutdownToken.trim();
+	if (!shutdownToken) {
+		throw new Error("Missing MCP shutdown token.");
+	}
+
+	const openaiApiKey = settings.openaiApiKey.trim();
+	if (!openaiApiKey) {
+		throw new Error(
+			"Missing OpenAI API key. Set it in Settings → Community plugins → AILSS Obsidian.",
+		);
+	}
+
+	const mcpCommand = settings.mcpCommand.trim();
+	const mcpArgs = options.resolveMcpHttpArgs();
+	if (!mcpCommand || mcpArgs.length === 0) {
+		throw new Error(
+			"Missing MCP HTTP server args. Build @ailss/mcp and ensure dist/http.js exists (or configure the MCP server path in settings).",
+		);
+	}
+
+	const { port, topK } = await options.normalizeStartupSettings(settings);
+	return {
+		settings,
+		host: "127.0.0.1",
+		port,
+		topK,
+		token,
+		shutdownToken,
+		openaiApiKey,
+		mcpCommand,
+		mcpArgs,
+		vaultPath: options.getVaultPath(),
+	};
+}

--- a/packages/obsidian-plugin/src/mcp/httpService/shutdownClient.ts
+++ b/packages/obsidian-plugin/src/mcp/httpService/shutdownClient.ts
@@ -1,0 +1,110 @@
+import http from "node:http";
+
+export type ShutdownRequestResult = { ok: boolean; status: number | null };
+
+export async function requestShutdown(options: {
+	host: string;
+	port: number;
+	tokens: string[];
+	requestShutdownOnce: (options: {
+		host: string;
+		port: number;
+		token: string;
+	}) => Promise<ShutdownRequestResult>;
+}): Promise<boolean> {
+	const tokens = Array.from(
+		new Set(options.tokens.map((t) => t.trim()).filter((t) => t.length > 0)),
+	);
+	if (tokens.length === 0) return false;
+
+	for (let i = 0; i < tokens.length; i++) {
+		const token = tokens[i];
+		if (!token) continue;
+
+		const res = await options.requestShutdownOnce({
+			host: options.host,
+			port: options.port,
+			token,
+		});
+
+		if (res.ok) return true;
+		if (res.status === 401 && i < tokens.length - 1) continue;
+		return false;
+	}
+
+	return false;
+}
+
+export async function requestShutdownOnce(options: {
+	host: string;
+	port: number;
+	token: string;
+	recordError: (message: string) => void;
+}): Promise<ShutdownRequestResult> {
+	// Use Node's HTTP client instead of `fetch` to avoid CORS/preflight issues in the
+	// Obsidian renderer context.
+	return await new Promise<ShutdownRequestResult>((resolve) => {
+		let settled = false;
+
+		const finish = (ok: boolean, status: number | null, errorMessage?: string) => {
+			if (settled) return;
+			settled = true;
+
+			if (errorMessage) {
+				options.recordError(errorMessage);
+			}
+
+			resolve({ ok, status });
+		};
+
+		const req = http.request(
+			{
+				hostname: options.host,
+				port: options.port,
+				path: "/__ailss/shutdown",
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${options.token}`,
+				},
+			},
+			(res) => {
+				res.setEncoding("utf8");
+
+				let body = "";
+				res.on("data", (chunk) => {
+					body += chunk;
+				});
+
+				res.on("end", () => {
+					const status = res.statusCode ?? 0;
+					if (status >= 200 && status < 300) {
+						finish(true, status);
+						return;
+					}
+
+					const message =
+						status === 401
+							? "Port is in use and shutdown was unauthorized (token mismatch)."
+							: status === 404
+								? "Port is in use and the service does not support remote shutdown."
+								: `Port is in use and shutdown failed (HTTP ${status}).`;
+					const detail = body.trim();
+					finish(false, status, detail ? `${message}\n${detail}` : message);
+				});
+			},
+		);
+
+		req.setTimeout(1_500, () => {
+			req.destroy(new Error("Request timed out."));
+		});
+
+		req.on("error", (error) => {
+			const e = error as { message?: string; code?: string };
+			const suffix = e.code ? `${e.code}: ` : "";
+			const message = `${suffix}${e.message ?? String(error)}`;
+			finish(false, null, `Port is in use and shutdown request failed: ${message}`);
+		});
+
+		req.end();
+	});
+}

--- a/packages/obsidian-plugin/src/mcp/httpService/spawnPlan.ts
+++ b/packages/obsidian-plugin/src/mcp/httpService/spawnPlan.ts
@@ -1,0 +1,51 @@
+import { DEFAULT_SETTINGS } from "../../settings.js";
+import { nodeNotFoundMessage, resolveSpawnCommandAndEnv } from "../../utils/spawn.js";
+
+import { type StartupPreflight } from "./preflight.js";
+
+export type SpawnPlan = {
+	command: string;
+	args: string[];
+	cwd: string | null;
+	env: NodeJS.ProcessEnv;
+};
+
+export function buildSpawnPlan(options: {
+	preflight: StartupPreflight;
+	cwd: string | null;
+}): SpawnPlan {
+	const env = buildServiceEnv(options.preflight);
+	const spawnEnv = { ...process.env, ...env };
+	const resolved = resolveSpawnCommandAndEnv(options.preflight.mcpCommand, spawnEnv);
+	if (resolved.command === "node") {
+		throw new Error(nodeNotFoundMessage("MCP"));
+	}
+
+	return {
+		command: resolved.command,
+		args: options.preflight.mcpArgs,
+		cwd: options.cwd,
+		env: resolved.env,
+	};
+}
+
+export function buildServiceEnv(preflight: StartupPreflight): Record<string, string> {
+	const env: Record<string, string> = {
+		OPENAI_API_KEY: preflight.openaiApiKey,
+		OPENAI_EMBEDDING_MODEL:
+			preflight.settings.openaiEmbeddingModel.trim() || DEFAULT_SETTINGS.openaiEmbeddingModel,
+		AILSS_VAULT_PATH: preflight.vaultPath,
+		AILSS_MCP_HTTP_HOST: preflight.host,
+		AILSS_MCP_HTTP_PORT: String(preflight.port),
+		AILSS_MCP_HTTP_PATH: "/mcp",
+		AILSS_MCP_HTTP_TOKEN: preflight.token,
+		AILSS_MCP_HTTP_SHUTDOWN_TOKEN: preflight.shutdownToken,
+		AILSS_GET_CONTEXT_DEFAULT_TOP_K: String(preflight.topK),
+	};
+
+	if (preflight.settings.mcpHttpServiceEnableWriteTools) {
+		env.AILSS_ENABLE_WRITE_TOOLS = "1";
+	}
+
+	return env;
+}


### PR DESCRIPTION
## What

- Extracted MCP HTTP service helpers from `packages/obsidian-plugin/src/mcp/mcpHttpServiceController.ts` into `packages/obsidian-plugin/src/mcp/httpService/` (`preflight.ts`, `spawnPlan.ts`, `durableLog.ts`, `shutdownClient.ts`, `messages.ts`).
- Controller remains focused on lifecycle orchestration.

## Why

- Reduce review surface area and make shutdown/log/spawn/preflight logic isolated and testable.
- Fixes #143

## How

- Kept the controller public API unchanged (`start/stop/restart` + getters) and preserved Notice text, timeouts, and durable log format/path.
- Validation: `pnpm build`, `pnpm test`, `pnpm typecheck`.
