### PR TITLE
fix: tolerate */* and JSON-only Accept in MCP HTTP JSON mode

### DIFF
--- a/packages/mcp/test/httpTransport.responseFormat.test.ts
+++ b/packages/mcp/test/httpTransport.responseFormat.test.ts
@@ -73,6 +73,48 @@ describe("MCP HTTP server (Streamable HTTP response format)", () => {
     });
   });
 
+  it("accepts JSON-only clients in JSON response mode (compat)", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const res = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-json-only",
+          accept: "application/json",
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.contentType.startsWith("application/json")).toBe(true);
+        expect(res.sessionId).toBeTruthy();
+        assertRecord(res.payload, "initialize payload");
+        expect(res.payload).toHaveProperty("result");
+      });
+    });
+  });
+
+  it("accepts */* clients in JSON response mode (compat)", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const res = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-any",
+          accept: "*/*",
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.contentType.startsWith("application/json")).toBe(true);
+        expect(res.sessionId).toBeTruthy();
+        assertRecord(res.payload, "initialize payload");
+        expect(res.payload).toHaveProperty("result");
+      });
+    });
+  });
+
   it("rejects clients that do not accept both application/json and text/event-stream", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");


### PR DESCRIPTION
## What

- In JSON response mode, normalize POST `Accept` to `application/json, text/event-stream` when the client sends `*/*` or JSON-only.
- Add tests covering JSON-only and `*/*` Accept headers in JSON response mode.

## Why

- Some Streamable HTTP clients (e.g. rmcp) intermittently send `Accept: */*` or `Accept: application/json` only, which MCP SDK rejects with 406.
- Those 406 responses may omit `Content-Type`, which can surface as `error decoding response body` client-side.

- Fixes #149

## How

- `packages/mcp/src/httpServerRoutes.ts`: coerce `req.headers.accept` before calling `StreamableHTTPServerTransport.handleRequest` when `enableJsonResponse` is enabled.
- `packages/mcp/test/httpTransport.responseFormat.test.ts`: add coverage for `Accept: application/json` and `Accept: */*` in JSON response mode.
