### PR TITLE
fix: tolerate wildcard Accept on MCP HTTP GET stream

### DIFF
--- a/packages/mcp/src/httpServerRoutes.ts
+++ b/packages/mcp/src/httpServerRoutes.ts
@@ -204,6 +204,7 @@ function coerceAcceptHeaderForJsonResponseMode(
     // but the SDK's simplistic check would otherwise reject the request.
     const acceptsSseQ = getEffectiveQForMediaType(ranges, "text", "event-stream", {
       acceptHeaderPresent,
+      ignoreRangesWithNonQParams: true,
     });
     if (acceptsSseQ <= 0) return;
 

--- a/packages/mcp/test/httpTestUtils.ts
+++ b/packages/mcp/test/httpTestUtils.ts
@@ -304,7 +304,10 @@ export async function mcpDeleteSession(
   });
 
   expect(res.status).toBe(200);
-  await res.text();
+  // Streamable HTTP SDK returns empty body on successful DELETE; avoid advertising JSON content-type.
+  expect(res.headers.get("content-type")).toBeFalsy();
+  const body = await res.text();
+  expect(body).toBe("");
 }
 
 function expectSessionNotFoundWithRecoveryHint(payload: unknown): void {

--- a/packages/mcp/test/httpTransport.responseFormat.test.ts
+++ b/packages/mcp/test/httpTransport.responseFormat.test.ts
@@ -115,6 +115,40 @@ describe("MCP HTTP server (Streamable HTTP response format)", () => {
     });
   });
 
+  it("accepts */* clients for GET SSE stream in JSON response mode (compat)", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const initRes = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-any-get-sse",
+          accept: "*/*",
+        });
+
+        expect(initRes.status).toBe(200);
+        expect(initRes.sessionId).toBeTruthy();
+
+        const res = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "*/*",
+            "mcp-session-id": initRes.sessionId as string,
+          },
+        });
+
+        expect(res.status).toBe(200);
+        expect((res.headers.get("content-type") ?? "").startsWith("text/event-stream")).toBe(true);
+
+        if (res.body) {
+          await res.body.cancel();
+        }
+      });
+    });
+  });
+
   it("does not coerce clients that explicitly reject application/json (q=0)", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");

--- a/packages/mcp/test/httpTransport.responseFormat.test.ts
+++ b/packages/mcp/test/httpTransport.responseFormat.test.ts
@@ -149,6 +149,76 @@ describe("MCP HTTP server (Streamable HTTP response format)", () => {
     });
   });
 
+  it("does not coerce JSON-only clients for GET SSE stream in JSON response mode", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const initRes = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-json-only-get-sse",
+          accept: "*/*",
+        });
+
+        expect(initRes.status).toBe(200);
+        expect(initRes.sessionId).toBeTruthy();
+
+        const res = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/json",
+            "mcp-session-id": initRes.sessionId as string,
+          },
+        });
+
+        expect(res.status).toBe(406);
+        expect((res.headers.get("content-type") ?? "").length > 0).toBe(true);
+
+        const body = await res.text();
+        const payload = parseFirstMcpPayload(body);
+        assertRecord(payload, "error payload");
+        expect(payload).toHaveProperty("error.message");
+      });
+    });
+  });
+
+  it("does not coerce GET clients that reject SSE via q-values", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const initRes = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-rejects-sse-get-sse",
+          accept: "*/*",
+        });
+
+        expect(initRes.status).toBe(200);
+        expect(initRes.sessionId).toBeTruthy();
+
+        const res = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "text/*;q=0, application/json",
+            "mcp-session-id": initRes.sessionId as string,
+          },
+        });
+
+        expect(res.status).toBe(406);
+        expect((res.headers.get("content-type") ?? "").length > 0).toBe(true);
+
+        const body = await res.text();
+        const payload = parseFirstMcpPayload(body);
+        assertRecord(payload, "error payload");
+        expect(payload).toHaveProperty("error.message");
+      });
+    });
+  });
+
   it("does not coerce clients that explicitly reject application/json (q=0)", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");


### PR DESCRIPTION
## What

- Coerce Accept for GET /mcp in JSON response mode to include text/event-stream when missing.
- Pre-set Content-Type: application/json; charset=utf-8 before delegating to the MCP SDK transport, so SDK error responses remain decodable.
- Add a regression test for GET /mcp Accept coercion in JSON response mode.

## Why

- Codex/rmcp clients may open the standalone GET SSE stream with Accept: */* or JSON-only and receive 406 without a Content-Type, which can surface as "error decoding response body".

## How

- Extend coerceAcceptHeaderForJsonResponseMode to handle GET separately (append text/event-stream when needed).
- Set a default JSON Content-Type header on responses before transport.handleRequest().
- Validation: pnpm build; pnpm test; pnpm check (pre-push hook)