### PR TITLE
fix: accept */* for GET SSE in JSON response mode

### DIFF
--- a/packages/mcp/test/httpTransport.responseFormat.test.ts
+++ b/packages/mcp/test/httpTransport.responseFormat.test.ts
@@ -115,6 +115,40 @@ describe("MCP HTTP server (Streamable HTTP response format)", () => {
     });
   });
 
+  it("accepts */* clients for GET SSE stream in JSON response mode (compat)", async () => {
+    await withTempDir("ailss-mcp-http-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      await withMcpHttpServer({ dbPath, enableWriteTools: false }, async ({ url, token }) => {
+        const initRes = await mcpInitializeRaw({
+          url,
+          token,
+          clientName: "client-any-get-sse",
+          accept: "*/*",
+        });
+
+        expect(initRes.status).toBe(200);
+        expect(initRes.sessionId).toBeTruthy();
+
+        const res = await fetch(url, {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "*/*",
+            "mcp-session-id": initRes.sessionId as string,
+          },
+        });
+
+        expect(res.status).toBe(200);
+        expect((res.headers.get("content-type") ?? "").startsWith("text/event-stream")).toBe(true);
+
+        if (res.body) {
+          await res.body.cancel();
+        }
+      });
+    });
+  });
+
   it("does not coerce clients that explicitly reject application/json (q=0)", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");


### PR DESCRIPTION
## What

- Coerce `Accept` for GET `/mcp` in JSON response mode to include `text/event-stream`.
- Pre-set `Content-Type: application/json; charset=utf-8` before delegating to the MCP SDK transport so SDK error responses remain decodable.
- Add regression coverage for GET Accept coercion.

## Why

- Codex/rmcp Streamable HTTP clients can send `Accept: */*` (or omit it) when opening the standalone SSE stream.
- The MCP SDK currently returns 406 for GET without `text/event-stream`, and those SDK error responses do not include `Content-Type`, which can surface as `error decoding response body`.

## How

- In `coerceAcceptHeaderForJsonResponseMode`, append `text/event-stream` for GET requests when missing.
- Set `content-type` on the Node response before calling `transport.handleRequest`.
- Verify with `pnpm check` and added Vitest coverage.