### PR TITLE
fix: disable default MCP HTTP idle session eviction

### DIFF
--- a/docs/03-plan.md
+++ b/docs/03-plan.md
@@ -315,8 +315,8 @@ Status (implemented):
 
 - Implemented in `packages/mcp/src/httpServer.ts` using a session manager that creates one server + transport per `initialize`.
 - Defaults:
-  - `AILSS_MCP_HTTP_MAX_SESSIONS=50`
-  - `AILSS_MCP_HTTP_IDLE_TTL_MS=3600000` (1 hour)
+  - `AILSS_MCP_HTTP_MAX_SESSIONS=100`
+  - `AILSS_MCP_HTTP_IDLE_TTL_MS=0` (disable idle expiration)
   - `AILSS_MCP_HTTP_SHUTDOWN_TOKEN=<token>` (optional; enables `POST /__ailss/shutdown`; use a separate admin token)
 
 Why this needs explicit design:

--- a/packages/mcp/src/httpServerConfig.ts
+++ b/packages/mcp/src/httpServerConfig.ts
@@ -57,16 +57,16 @@ export function parseHttpConfigFromEnv(): HttpConfig {
 }
 
 export function parseMaxSessionsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "50").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_MAX_SESSIONS ?? "100").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 1) return 50;
+  if (!Number.isFinite(n) || n < 1) return 100;
   return n;
 }
 
 export function parseIdleTtlMsFromEnv(): number {
-  const raw = (process.env.AILSS_MCP_HTTP_IDLE_TTL_MS ?? "3600000").trim();
+  const raw = (process.env.AILSS_MCP_HTTP_IDLE_TTL_MS ?? "0").trim();
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n) || n < 0) return 3_600_000;
+  if (!Number.isFinite(n) || n < 0) return 0;
   return n;
 }
 

--- a/packages/mcp/test/httpServerConfig.unit.test.ts
+++ b/packages/mcp/test/httpServerConfig.unit.test.ts
@@ -100,13 +100,13 @@ describe("httpServerConfig helpers", () => {
   it("parses max sessions and idle ttl with safe defaults", () => {
     delete process.env.AILSS_MCP_HTTP_MAX_SESSIONS;
     delete process.env.AILSS_MCP_HTTP_IDLE_TTL_MS;
-    expect(parseMaxSessionsFromEnv()).toBe(50);
-    expect(parseIdleTtlMsFromEnv()).toBe(3_600_000);
+    expect(parseMaxSessionsFromEnv()).toBe(100);
+    expect(parseIdleTtlMsFromEnv()).toBe(0);
 
     process.env.AILSS_MCP_HTTP_MAX_SESSIONS = "abc";
     process.env.AILSS_MCP_HTTP_IDLE_TTL_MS = "-1";
-    expect(parseMaxSessionsFromEnv()).toBe(50);
-    expect(parseIdleTtlMsFromEnv()).toBe(3_600_000);
+    expect(parseMaxSessionsFromEnv()).toBe(100);
+    expect(parseIdleTtlMsFromEnv()).toBe(0);
 
     process.env.AILSS_MCP_HTTP_MAX_SESSIONS = "12";
     process.env.AILSS_MCP_HTTP_IDLE_TTL_MS = "2500";

--- a/packages/mcp/test/httpSessions.defaultMaxSessions.test.ts
+++ b/packages/mcp/test/httpSessions.defaultMaxSessions.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./httpTestUtils.js";
 
 describe("MCP HTTP server (default max sessions)", () => {
-  it("uses 50 as the default max session cap when env override is missing", async () => {
+  it("uses 100 as the default max session cap when env override is missing", async () => {
     await withTempDir("ailss-mcp-http-", async (dir) => {
       const dbPath = path.join(dir, "index.sqlite");
 
@@ -39,19 +39,19 @@ describe("MCP HTTP server (default max sessions)", () => {
           try {
             const sessions: string[] = [];
 
-            for (let i = 0; i < 21; i++) {
+            for (let i = 0; i < 41; i++) {
               sessions.push(await mcpInitialize(url, token, `client-${i}`));
             }
 
             await mcpToolsList(url, token, sessions[0]!);
-            await mcpToolsList(url, token, sessions[20]!);
+            await mcpToolsList(url, token, sessions[40]!);
 
-            for (let i = 21; i < 51; i++) {
+            for (let i = 41; i < 101; i++) {
               sessions.push(await mcpInitialize(url, token, `client-${i}`));
             }
 
             await mcpToolsListExpectSessionNotFound(url, token, sessions[1]!);
-            await mcpToolsList(url, token, sessions[50]!);
+            await mcpToolsList(url, token, sessions[100]!);
           } finally {
             await close();
             runtime.deps.db.close();


### PR DESCRIPTION
## What

- Default `AILSS_MCP_HTTP_IDLE_TTL_MS` to `0` (disable idle expiration)
- Default `AILSS_MCP_HTTP_MAX_SESSIONS` to `100` (keep a hard cap)

## Why

- Prevent long-running Codex sessions from failing after idle eviction with `-32001 Session not found`
- Fixes #158

## How

- Update fallback defaults in `packages/mcp/src/httpServerConfig.ts`
- Update related MCP HTTP tests
- Update defaults section in `docs/03-plan.md`
