### PR TITLE
refactor: split frontmatter enum schema module and add docs drift guard

### DIFF
--- a/docs/standards/vault/frontmatter-schema.md
+++ b/docs/standards/vault/frontmatter-schema.md
@@ -32,6 +32,7 @@ source: []
 - The `entity` field should use an allowed type (concept, document, project, guide, tool, etc.).
 - The `layer` field should be one of: strategic, conceptual, logical, physical, operational.
 - The `status` field should be one of: draft, in-review, active, archived.
+- Source of truth for `entity`/`layer`/`status` allowed values is `packages/core/src/vault/frontmatterEnums.ts` (docs and code are validated for drift in CI).
 - Relationship keys should use the typed-link keys (see `./typed-links.md`).
 - If you are unsure, it is acceptable to leave `layer` empty temporarily and refine during review.
 - Fill `tags`, `aliases`, `keywords`, and `source` only when needed (but keep the keys present).

--- a/packages/core/src/vault/frontmatter.ts
+++ b/packages/core/src/vault/frontmatter.ts
@@ -13,175 +13,21 @@ export type TypedLink = {
   position: number;
 };
 
-// Frontmatter enums
-// - keep in sync with docs/standards/vault/frontmatter-schema.md
-export const AILSS_FRONTMATTER_STATUS_VALUES = [
-  "draft",
-  "in-review",
-  "active",
-  "archived",
-] as const;
-export type AilssFrontmatterStatus = (typeof AILSS_FRONTMATTER_STATUS_VALUES)[number];
-
-export const AILSS_FRONTMATTER_LAYER_VALUES = [
-  "strategic",
-  "conceptual",
-  "logical",
-  "physical",
-  "operational",
-] as const;
-export type AilssFrontmatterLayer = (typeof AILSS_FRONTMATTER_LAYER_VALUES)[number];
-
-export const AILSS_FRONTMATTER_ENTITY_VALUES = [
-  // Interface entities
-  "interface",
-  "pipeline",
-  "procedure",
-  "dashboard",
-  "checklist",
-  "workflow",
-
-  // Action entities
-  "decide",
-  "review",
-  "plan",
-  "implement",
-  "approve",
-  "reject",
-  "observe",
-  "measure",
-  "test",
-  "verify",
-  "learn",
-  "research",
-  "summarize",
-  "publish",
-  "meet",
-  "audit",
-  "deploy",
-  "rollback",
-  "refactor",
-  "design",
-  "delete",
-  "update",
-  "create",
-  "schedule",
-  "migrate",
-  "analyze",
-
-  // Object entities
-  "concept",
-  "document",
-  "project",
-  "artifact",
-  "person",
-  "organization",
-  "place",
-  "event",
-  "task",
-  "method",
-  "tool",
-  "idea",
-  "principle",
-  "heuristic",
-  "pattern",
-  "definition",
-  "question",
-  "software",
-  "dataset",
-  "reference",
-  "hub",
-  "guide",
-  "log",
-  "structure",
-  "architecture",
-] as const;
-export type AilssFrontmatterEntity = (typeof AILSS_FRONTMATTER_ENTITY_VALUES)[number];
-
-const AILSS_FRONTMATTER_STATUS_SET = new Set<string>(AILSS_FRONTMATTER_STATUS_VALUES);
-const AILSS_FRONTMATTER_LAYER_SET = new Set<string>(AILSS_FRONTMATTER_LAYER_VALUES);
-const AILSS_FRONTMATTER_ENTITY_SET = new Set<string>(AILSS_FRONTMATTER_ENTITY_VALUES);
-
-export function isAilssFrontmatterStatus(value: string): value is AilssFrontmatterStatus {
-  return AILSS_FRONTMATTER_STATUS_SET.has(value);
-}
-
-export function isAilssFrontmatterLayer(value: string): value is AilssFrontmatterLayer {
-  return AILSS_FRONTMATTER_LAYER_SET.has(value);
-}
-
-export function isAilssFrontmatterEntity(value: string): value is AilssFrontmatterEntity {
-  return AILSS_FRONTMATTER_ENTITY_SET.has(value);
-}
-
-export type AilssFrontmatterEnumViolation = {
-  key: "status" | "layer" | "entity";
-  value: string | null;
-  allowed: readonly string[];
-};
-
-export function validateAilssFrontmatterEnums(
-  frontmatter: Record<string, unknown>,
-): AilssFrontmatterEnumViolation[] {
-  const violations: AilssFrontmatterEnumViolation[] = [];
-  const hasOwn = (key: string) => Object.prototype.hasOwnProperty.call(frontmatter, key);
-  const describeValue = (value: unknown): string | null => {
-    if (value === null || value === undefined) return null;
-    if (typeof value === "string") return value.trim();
-    if (typeof value === "number" && Number.isFinite(value)) return String(value);
-    if (value instanceof Date && Number.isFinite(value.getTime()))
-      return value.toISOString().slice(0, 19);
-    try {
-      const json = JSON.stringify(value);
-      if (typeof json === "string") return json;
-    } catch {
-      // ignore
-    }
-    return String(value);
-  };
-
-  if (hasOwn("status")) {
-    const value = frontmatter.status;
-    const raw = coerceString(value);
-    if (!raw || !isAilssFrontmatterStatus(raw)) {
-      violations.push({
-        key: "status",
-        value: describeValue(value),
-        allowed: AILSS_FRONTMATTER_STATUS_VALUES,
-      });
-    }
-  }
-
-  if (hasOwn("layer")) {
-    const value = frontmatter.layer;
-    const raw = coerceString(value);
-    const isUnset =
-      value === null || value === undefined || (typeof value === "string" && !value.trim());
-    if (!isUnset && (!raw || !isAilssFrontmatterLayer(raw))) {
-      violations.push({
-        key: "layer",
-        value: describeValue(value),
-        allowed: AILSS_FRONTMATTER_LAYER_VALUES,
-      });
-    }
-  }
-
-  if (hasOwn("entity")) {
-    const value = frontmatter.entity;
-    const raw = coerceString(value);
-    const isUnset =
-      value === null || value === undefined || (typeof value === "string" && !value.trim());
-    if (!isUnset && (!raw || !isAilssFrontmatterEntity(raw))) {
-      violations.push({
-        key: "entity",
-        value: describeValue(value),
-        allowed: AILSS_FRONTMATTER_ENTITY_VALUES,
-      });
-    }
-  }
-
-  return violations;
-}
+export {
+  AILSS_FRONTMATTER_ENTITY_VALUES,
+  AILSS_FRONTMATTER_LAYER_VALUES,
+  AILSS_FRONTMATTER_STATUS_VALUES,
+  isAilssFrontmatterEntity,
+  isAilssFrontmatterLayer,
+  isAilssFrontmatterStatus,
+  validateAilssFrontmatterEnums,
+} from "./frontmatterEnums.js";
+export type {
+  AilssFrontmatterEntity,
+  AilssFrontmatterEnumViolation,
+  AilssFrontmatterLayer,
+  AilssFrontmatterStatus,
+} from "./frontmatterEnums.js";
 
 export type NormalizedAilssNoteMeta = {
   noteId: string | null;

--- a/packages/core/src/vault/frontmatterEnums.ts
+++ b/packages/core/src/vault/frontmatterEnums.ts
@@ -1,0 +1,187 @@
+// AILSS frontmatter enums + enum validation
+// - single source for status/layer/entity value constraints
+// - keep in sync with docs/standards/vault/frontmatter-schema.md
+
+export const AILSS_FRONTMATTER_STATUS_VALUES = [
+  "draft",
+  "in-review",
+  "active",
+  "archived",
+] as const;
+export type AilssFrontmatterStatus = (typeof AILSS_FRONTMATTER_STATUS_VALUES)[number];
+
+export const AILSS_FRONTMATTER_LAYER_VALUES = [
+  "strategic",
+  "conceptual",
+  "logical",
+  "physical",
+  "operational",
+] as const;
+export type AilssFrontmatterLayer = (typeof AILSS_FRONTMATTER_LAYER_VALUES)[number];
+
+export const AILSS_FRONTMATTER_ENTITY_VALUES = [
+  // Interface entities
+  "interface",
+  "pipeline",
+  "procedure",
+  "dashboard",
+  "checklist",
+  "workflow",
+
+  // Action entities
+  "decide",
+  "review",
+  "plan",
+  "implement",
+  "approve",
+  "reject",
+  "observe",
+  "measure",
+  "test",
+  "verify",
+  "learn",
+  "research",
+  "summarize",
+  "publish",
+  "meet",
+  "audit",
+  "deploy",
+  "rollback",
+  "refactor",
+  "design",
+  "delete",
+  "update",
+  "create",
+  "schedule",
+  "migrate",
+  "analyze",
+
+  // Object entities
+  "concept",
+  "document",
+  "project",
+  "artifact",
+  "person",
+  "organization",
+  "place",
+  "event",
+  "task",
+  "method",
+  "tool",
+  "idea",
+  "principle",
+  "heuristic",
+  "pattern",
+  "definition",
+  "question",
+  "software",
+  "dataset",
+  "reference",
+  "hub",
+  "guide",
+  "log",
+  "structure",
+  "architecture",
+] as const;
+export type AilssFrontmatterEntity = (typeof AILSS_FRONTMATTER_ENTITY_VALUES)[number];
+
+const AILSS_FRONTMATTER_STATUS_SET = new Set<string>(AILSS_FRONTMATTER_STATUS_VALUES);
+const AILSS_FRONTMATTER_LAYER_SET = new Set<string>(AILSS_FRONTMATTER_LAYER_VALUES);
+const AILSS_FRONTMATTER_ENTITY_SET = new Set<string>(AILSS_FRONTMATTER_ENTITY_VALUES);
+
+export function isAilssFrontmatterStatus(value: string): value is AilssFrontmatterStatus {
+  return AILSS_FRONTMATTER_STATUS_SET.has(value);
+}
+
+export function isAilssFrontmatterLayer(value: string): value is AilssFrontmatterLayer {
+  return AILSS_FRONTMATTER_LAYER_SET.has(value);
+}
+
+export function isAilssFrontmatterEntity(value: string): value is AilssFrontmatterEntity {
+  return AILSS_FRONTMATTER_ENTITY_SET.has(value);
+}
+
+export type AilssFrontmatterEnumViolation = {
+  key: "status" | "layer" | "entity";
+  value: string | null;
+  allowed: readonly string[];
+};
+
+function coerceFrontmatterEnumString(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  }
+
+  // YAML parsers (e.g. gray-matter/js-yaml) may infer types for unquoted scalars.
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value.toISOString().slice(0, 19);
+  }
+
+  return null;
+}
+
+function describeEnumValue(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (value instanceof Date && Number.isFinite(value.getTime()))
+    return value.toISOString().slice(0, 19);
+  try {
+    const json = JSON.stringify(value);
+    if (typeof json === "string") return json;
+  } catch {
+    // ignore
+  }
+  return String(value);
+}
+
+export function validateAilssFrontmatterEnums(
+  frontmatter: Record<string, unknown>,
+): AilssFrontmatterEnumViolation[] {
+  const violations: AilssFrontmatterEnumViolation[] = [];
+  const hasOwn = (key: string) => Object.prototype.hasOwnProperty.call(frontmatter, key);
+
+  if (hasOwn("status")) {
+    const value = frontmatter.status;
+    const raw = coerceFrontmatterEnumString(value);
+    if (!raw || !isAilssFrontmatterStatus(raw)) {
+      violations.push({
+        key: "status",
+        value: describeEnumValue(value),
+        allowed: AILSS_FRONTMATTER_STATUS_VALUES,
+      });
+    }
+  }
+
+  if (hasOwn("layer")) {
+    const value = frontmatter.layer;
+    const raw = coerceFrontmatterEnumString(value);
+    const isUnset =
+      value === null || value === undefined || (typeof value === "string" && !value.trim());
+    if (!isUnset && (!raw || !isAilssFrontmatterLayer(raw))) {
+      violations.push({
+        key: "layer",
+        value: describeEnumValue(value),
+        allowed: AILSS_FRONTMATTER_LAYER_VALUES,
+      });
+    }
+  }
+
+  if (hasOwn("entity")) {
+    const value = frontmatter.entity;
+    const raw = coerceFrontmatterEnumString(value);
+    const isUnset =
+      value === null || value === undefined || (typeof value === "string" && !value.trim());
+    if (!isUnset && (!raw || !isAilssFrontmatterEntity(raw))) {
+      violations.push({
+        key: "entity",
+        value: describeEnumValue(value),
+        allowed: AILSS_FRONTMATTER_ENTITY_VALUES,
+      });
+    }
+  }
+
+  return violations;
+}

--- a/packages/mcp/test/docs.frontmatterEnumConsistency.test.ts
+++ b/packages/mcp/test/docs.frontmatterEnumConsistency.test.ts
@@ -19,7 +19,7 @@ const EXPECTED_BY_KEY: Record<EnumKey, readonly string[]> = {
 };
 
 function extractTemplateCodeBlock(markdown: string): string {
-  const match = markdown.match(/```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```/);
+  const match = markdown.match(/```(?:[a-zA-Z]+)?\r?\n([\s\S]*?)\r?\n```/);
   if (!match || !match[1]) return "";
   return match[1];
 }

--- a/packages/mcp/test/docs.frontmatterEnumConsistency.test.ts
+++ b/packages/mcp/test/docs.frontmatterEnumConsistency.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AILSS_FRONTMATTER_ENTITY_VALUES,
+  AILSS_FRONTMATTER_LAYER_VALUES,
+  AILSS_FRONTMATTER_STATUS_VALUES,
+} from "@ailss/core";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+const DOC_PATH = "docs/standards/vault/frontmatter-schema.md";
+
+type EnumKey = "status" | "layer" | "entity";
+
+const EXPECTED_BY_KEY: Record<EnumKey, readonly string[]> = {
+  status: [...AILSS_FRONTMATTER_STATUS_VALUES],
+  layer: [...AILSS_FRONTMATTER_LAYER_VALUES],
+  entity: [...AILSS_FRONTMATTER_ENTITY_VALUES],
+};
+
+function extractTemplateCodeBlock(markdown: string): string {
+  const match = markdown.match(/```(?:[a-zA-Z]+)?\n([\s\S]*?)\n```/);
+  if (!match || !match[1]) return "";
+  return match[1];
+}
+
+function extractEnumValuesFromTemplate(template: string, key: EnumKey): string[] {
+  const lines = template.split(/\r?\n/);
+  const keyIndex = lines.findIndex((line) => line.trimStart().startsWith(`${key}:`));
+  if (keyIndex < 0) return [];
+
+  const precedingComments: string[] = [];
+  for (let i = keyIndex - 1; i >= 0; i -= 1) {
+    const trimmed = (lines[i] ?? "").trim();
+    if (!trimmed) continue;
+    if (!trimmed.startsWith("#")) break;
+    precedingComments.push(trimmed.slice(1).trim());
+  }
+
+  const enumLine = precedingComments[precedingComments.length - 1];
+  if (!enumLine) return [];
+  return enumLine
+    .split("|")
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function normalizeValues(values: readonly string[]): string[] {
+  const unique = new Set<string>();
+  for (const value of values) {
+    const normalized = value.trim();
+    if (!normalized) continue;
+    unique.add(normalized);
+  }
+  return [...unique].sort((a, b) => a.localeCompare(b));
+}
+
+describe("Docs frontmatter enum consistency", () => {
+  it("keeps frontmatter enum lists in docs in sync with core constants", async () => {
+    const absPath = path.join(process.cwd(), DOC_PATH);
+    const markdown = await fs.readFile(absPath, "utf8");
+    const template = extractTemplateCodeBlock(markdown);
+
+    const mismatches: Array<{
+      key: EnumKey;
+      expected: string[];
+      found: string[];
+      missing: string[];
+      extra: string[];
+    }> = [];
+
+    for (const [key, expectedValues] of Object.entries(EXPECTED_BY_KEY) as Array<
+      [EnumKey, readonly string[]]
+    >) {
+      const expected = normalizeValues(expectedValues);
+      const found = normalizeValues(extractEnumValuesFromTemplate(template, key));
+      const foundSet = new Set<string>(found);
+      const expectedSet = new Set<string>(expected);
+      const missing = expected.filter((value) => !foundSet.has(value));
+      const extra = found.filter((value) => !expectedSet.has(value));
+      if (missing.length > 0 || extra.length > 0) {
+        mismatches.push({ key, expected, found, missing, extra });
+      }
+    }
+
+    if (mismatches.length > 0) {
+      const details = mismatches.map((mismatch) => {
+        const missing = mismatch.missing.length > 0 ? mismatch.missing.join(", ") : "(none)";
+        const extra = mismatch.extra.length > 0 ? mismatch.extra.join(", ") : "(none)";
+        const found = mismatch.found.length > 0 ? mismatch.found.join(", ") : "(missing marker)";
+        return [
+          `- ${mismatch.key}`,
+          `  missing: ${missing}`,
+          `  extra: ${extra}`,
+          `  expected: ${mismatch.expected.join(", ")}`,
+          `  found: ${found}`,
+        ].join("\n");
+      });
+      throw new Error(
+        [
+          "Frontmatter enum drift detected between code and docs.",
+          `- file: ${DOC_PATH}`,
+          ...details,
+        ].join("\n"),
+      );
+    }
+
+    expect(mismatches).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

- Split frontmatter enum schema concerns (`status`/`layer`/`entity`) into a dedicated core module: `packages/core/src/vault/frontmatterEnums.ts`.
- Kept `packages/core/src/vault/frontmatter.ts` focused on normalization logic, while preserving external enum/validator exports via re-export.
- Added a docs drift guard test that fails when frontmatter enum lists in `docs/standards/vault/frontmatter-schema.md` diverge from core constants.
- Documented enum value source-of-truth policy in `docs/standards/vault/frontmatter-schema.md`.

## Why

- `frontmatter.ts` was mixing enum schema/validation with normalization responsibilities, increasing coupling.
- Isolating enum schema reduces future circular-dependency pressure and makes follow-up type-hardening safer.
- There was no automated guard for enum drift between docs and code.

- Fixes #165

## How

- Added `frontmatterEnums.ts` with constants, union types, guards, and `validateAilssFrontmatterEnums`.
- Re-exported enum APIs from `frontmatter.ts` to avoid downstream import breakage.
- Added `packages/mcp/test/docs.frontmatterEnumConsistency.test.ts` to compare doc template enum lists vs core constants (set equality).
- Updated docs with explicit source-of-truth note and validated via `pnpm check`.
