### PR TITLE
feat: verify Python parity for the current MCP read/write tool surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Full reference: `docs/01-overview.md` and `docs/reference/mcp-tools.md`.
 - `docs/README.md`: documentation index
 - `docs/01-overview.md`: architecture + MCP tool surface
 - `docs/architecture/python-first-local-agent-backend.md`: transition baseline, service boundaries, API contract
+- `docs/architecture/python-mcp-parity.md`: parity target, migration gate, and current gaps for the MCP tool surface
 - `docs/ops/codex-cli.md`: Codex CLI setup
 - `docs/ops/local-dev.md`: local development
 - `docs/standards/vault/README.md`: vault model and rules

--- a/apps/api/tests/helpers.py
+++ b/apps/api/tests/helpers.py
@@ -155,6 +155,7 @@ def seed_index_db(db_path: Path) -> None:
             "INSERT INTO note_tags(path, tag) VALUES (?, ?)",
             [
                 ("docs/03-plan.md", "architecture"),
+                ("docs/03-plan.md", "project"),
                 ("notes/random.md", "misc"),
             ],
         )

--- a/apps/api/tests/test_parity_contract.py
+++ b/apps/api/tests/test_parity_contract.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import get_args
+
+from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
+
+from ailss_api.main import create_app
+from ailss_api.models import FailureCode
+from tests.helpers import (
+    DEFAULT_AGENT_INPUT,
+    DEFAULT_RETRIEVE_QUERY,
+    build_settings_with_seed_data,
+    set_fake_embedding,
+)
+
+PARITY_DOC_PATH = (
+    Path(__file__).resolve().parents[3] / "docs" / "architecture" / "python-mcp-parity.md"
+)
+
+
+def _extract_bulleted_code_items(markdown: str, heading: str) -> list[str]:
+    lines = markdown.splitlines()
+    heading_index = next(
+        (index for index, line in enumerate(lines) if line.strip() == heading),
+        -1,
+    )
+    if heading_index < 0:
+        return []
+
+    values: list[str] = []
+    for line in lines[heading_index + 1 :]:
+        stripped = line.strip()
+        if not stripped:
+            if values:
+                break
+            continue
+        if stripped.startswith("#"):
+            break
+
+        match = re.match(r"^- `([^`]+)`$", stripped)
+        if match is None:
+            continue
+        values.append(match.group(1))
+    return values
+
+
+def test_parity_doc_lists_current_agent_failure_codes() -> None:
+    doc = PARITY_DOC_PATH.read_text(encoding="utf-8")
+
+    documented = sorted(
+        _extract_bulleted_code_items(
+            doc,
+            "## Required failure codes for Python-covered agent flows",
+        )
+    )
+    actual = sorted(get_args(FailureCode))
+
+    assert documented == actual
+
+
+def test_retrieve_parity_respects_combined_scope_filters(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    settings = build_settings_with_seed_data(tmp_path)
+    set_fake_embedding(monkeypatch)
+    client = TestClient(create_app(settings))
+
+    response = client.post(
+        "/retrieve",
+        json={
+            "query": DEFAULT_RETRIEVE_QUERY,
+            "top_k": 3,
+            "path_prefix": "docs/",
+            "tags_any": ["project"],
+            "tags_all": ["architecture", "project"],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert [result["path"] for result in payload["results"]] == ["docs/03-plan.md"]
+    assert set(payload["results"][0]["tags"]) == {"architecture", "project"}
+
+
+def test_agent_run_returns_missing_context_when_scoped_filters_remove_candidates(
+    tmp_path: Path, monkeypatch: MonkeyPatch
+) -> None:
+    settings = build_settings_with_seed_data(tmp_path)
+    set_fake_embedding(monkeypatch)
+    client = TestClient(create_app(settings))
+
+    response = client.post(
+        "/agent/run",
+        json={
+            "input": DEFAULT_AGENT_INPUT,
+            "context": {
+                "path_prefix": "notes/",
+                "tags_all": ["architecture"],
+                "top_k": 1,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["outcome"] == "failed"
+    assert payload["failure"]["code"] == "missing_context"
+
+
+def test_agent_run_rejects_write_request_with_apply_true(tmp_path: Path) -> None:
+    settings = build_settings_with_seed_data(tmp_path)
+    client = TestClient(create_app(settings))
+
+    response = client.post(
+        "/agent/run",
+        json={
+            "input": "Write the summary into a new note.",
+            "requested_write_action": "capture_note",
+            "apply": True,
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["outcome"] == "failed"
+    assert payload["failure"]["code"] == "write_not_allowed"
+    assert payload["write_actions"] == [
+        {
+            "action": "capture_note",
+            "allowed": False,
+            "reason": "write_not_allowed",
+        }
+    ]

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This folder is organized so you can read the AILSS system docs in order: **Conte
 
 - Package structure: [architecture/packages.md](./architecture/packages.md)
 - Python-first local agent baseline: [architecture/python-first-local-agent-backend.md](./architecture/python-first-local-agent-backend.md)
+- Python parity for MCP tool surface: [architecture/python-mcp-parity.md](./architecture/python-mcp-parity.md)
 - Data & database: [architecture/data-db.md](./architecture/data-db.md)
 
 ## Ops

--- a/docs/architecture/python-mcp-parity.md
+++ b/docs/architecture/python-mcp-parity.md
@@ -1,0 +1,88 @@
+# Architecture: Python parity for the current MCP tool surface
+
+This document defines the parity boundary tracked by issue #182.
+
+It does not claim that the current Python backend already replaces the Node/MCP runtime.
+Instead, it records which MCP behaviors must match before any later migration removes the
+existing Node path, which differences are acceptable during the current baseline, and which
+tools remain explicit gaps.
+
+## Terms
+
+- Exact-match parity: behavior, safety constraints, and failure semantics must stay aligned
+  with the current MCP contract before the Node path can be removed.
+- Acceptable baseline difference: a documented difference that is allowed while the Node/MCP
+  path remains the source of truth for that capability.
+- Gap / Node-only: there is no public Python replacement yet; the current MCP tool must stay
+  on the Node path.
+
+## Current parity boundary
+
+- Python-covered now:
+  - `/retrieve` is the Python-side parity target for `get_context`-style retrieval behavior.
+  - `/agent/run` is the Python-side parity target for grounded-answer behavior and explicit
+    write refusal semantics.
+- Still Node-owned now:
+  - MCP transport, indexer ownership, filesystem read tools, graph/navigation tools,
+    metadata/list tools, diagnostics tools, and all explicit write tools.
+- Migration gate:
+  - Do not remove the Node/TypeScript path until every `Gap / Node-only` row below has an
+    exact-match Python replacement or an explicitly accepted new contract.
+
+## Read tool parity matrix
+
+| Tool                          | Current Python target                                   | Status          | Exact-match requirements before migration                                                                                                                                                 | Acceptable baseline differences / current gap                                                                                                                         |
+| ----------------------------- | ------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_context`                 | `/retrieve` and the retrieval stage inside `/agent/run` | Partial parity  | Preserve scoped candidate filtering (`path_prefix`, `tags_any`, `tags_all`), explicit readiness failures, grounded evidence, and no unrelated fallback when scope removes all candidates. | Response shape differs from MCP `structuredContent`; Python caps `top_k` at `20`; Python does not expose MCP-only fields such as `expand_top_k` or `applied_filters`. |
+| `expand_typed_links_outgoing` | None                                                    | Gap / Node-only | Add a Python graph expansion contract that preserves bounded traversal semantics before migration.                                                                                        | No Python graph traversal API exists yet.                                                                                                                             |
+| `resolve_note`                | None                                                    | Gap / Node-only | Add a Python note-resolution contract before migration.                                                                                                                                   | No Python resolution endpoint exists yet.                                                                                                                             |
+| `find_typed_links_incoming`   | None                                                    | Gap / Node-only | Add a Python incoming-link query contract before migration.                                                                                                                               | No Python backref query exists yet.                                                                                                                                   |
+| `list_typed_link_rels`        | None                                                    | Gap / Node-only | Add a Python relation-listing contract before migration.                                                                                                                                  | No Python typed-link relation listing exists yet.                                                                                                                     |
+| `read_note`                   | Internal note reads inside `/agent/run` only            | Gap / Node-only | Add a public Python note-read contract with the current vault-boundary guarantees before migration.                                                                                       | The current Python backend only reads note excerpts internally; it does not expose the public pagination/change-token contract of `read_note`.                        |
+| `get_vault_tree`              | None                                                    | Gap / Node-only | Add a Python vault-tree contract before migration.                                                                                                                                        | No Python vault-tree API exists yet.                                                                                                                                  |
+| `frontmatter_validate`        | None                                                    | Gap / Node-only | Add a Python validator contract that preserves the current schema and typed-link diagnostic expectations before migration.                                                                | No Python frontmatter validation API exists yet.                                                                                                                      |
+| `find_broken_links`           | None                                                    | Gap / Node-only | Add a Python broken-link diagnostic contract before migration.                                                                                                                            | No Python broken-link diagnostic API exists yet.                                                                                                                      |
+| `search_notes`                | None                                                    | Gap / Node-only | Add a Python metadata-search contract before migration.                                                                                                                                   | No Python metadata-search API exists yet.                                                                                                                             |
+| `list_tags`                   | None                                                    | Gap / Node-only | Add a Python tag-listing contract before migration.                                                                                                                                       | No Python tag-listing API exists yet.                                                                                                                                 |
+| `list_keywords`               | None                                                    | Gap / Node-only | Add a Python keyword-listing contract before migration.                                                                                                                                   | No Python keyword-listing API exists yet.                                                                                                                             |
+| `get_tool_failure_report`     | None                                                    | Gap / Node-only | Add a Python diagnostics-report contract before migration.                                                                                                                                | No Python diagnostics-report API exists yet.                                                                                                                          |
+
+## Write tool parity matrix
+
+| Tool                       | Current Python target          | Status          | Exact-match requirements before migration                                                                        | Acceptable baseline differences / current gap                                                       |
+| -------------------------- | ------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `capture_note`             | `/agent/run` refusal path only | Gap / Node-only | Preserve explicit `apply` gating and current vault-write safety before any Python write path replaces this tool. | The current Python baseline never creates notes. It only returns explicit refusal semantics.        |
+| `canonicalize_typed_links` | `/agent/run` refusal path only | Gap / Node-only | Preserve explicit `apply` gating and safe deterministic mutation rules before migration.                         | The current Python baseline never rewrites typed links. It only returns explicit refusal semantics. |
+| `edit_note`                | `/agent/run` refusal path only | Gap / Node-only | Preserve explicit `apply` gating, concurrency guards, and vault-boundary safety before migration.                | The current Python baseline never edits notes. It only returns explicit refusal semantics.          |
+| `improve_frontmatter`      | `/agent/run` refusal path only | Gap / Node-only | Preserve explicit `apply` gating and current frontmatter safety rules before migration.                          | The current Python baseline never mutates frontmatter. It only returns explicit refusal semantics.  |
+| `relocate_note`            | `/agent/run` refusal path only | Gap / Node-only | Preserve explicit `apply` gating and current path safety rules before migration.                                 | The current Python baseline never moves notes. It only returns explicit refusal semantics.          |
+
+## Safety invariants that must not regress
+
+- Vault boundary: Python note reads must stay within `AILSS_VAULT_PATH`; path traversal or
+  absolute-escape attempts must not read outside the configured vault.
+- Write gating: requested writes must fail explicitly unless the future Python path has an
+  approved replacement for the current MCP write contract.
+- Failure visibility: missing or invalid local prerequisites must fail explicitly rather than
+  silently degrading to unrelated retrieval results.
+- Grounding: Python-generated answers must keep inspectable citations; missing evidence is a
+  failure, not a best-effort answer.
+
+## Required failure codes for Python-covered agent flows
+
+- `missing_context`
+- `ambiguous_note_resolution`
+- `grounding_failure`
+- `write_not_allowed`
+- `apply_not_requested`
+
+## Verification currently in repo
+
+- `packages/mcp/test/docs.mcpToolingConsistency.test.ts`
+  - Keeps this parity matrix aligned with the live MCP tool surface.
+- `apps/api/tests/test_parity_contract.py`
+  - Verifies the documented Python parity-critical behaviors that already exist in the
+    baseline.
+- Existing Python route/unit coverage:
+  - `apps/api/tests/test_retrieve.py`
+  - `apps/api/tests/test_agent.py`

--- a/packages/mcp/test/docs.mcpToolingConsistency.test.ts
+++ b/packages/mcp/test/docs.mcpToolingConsistency.test.ts
@@ -105,6 +105,47 @@ function extractToolListFromOverview(markdown: string, sectionHeading: string): 
   return out.sort((a, b) => a.localeCompare(b));
 }
 
+function extractToolListFromTable(markdown: string, sectionHeading: string): string[] {
+  const lines = markdown.split(/\r?\n/);
+  const headingIndex = lines.findIndex((l) => l.trim() === sectionHeading);
+  if (headingIndex < 0) return [];
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  let inTable = false;
+
+  for (let i = headingIndex + 1; i < lines.length; i += 1) {
+    const rawLine = lines[i] ?? "";
+    const line = rawLine.trim();
+
+    if (!line) {
+      if (inTable) break;
+      continue;
+    }
+
+    if (line.startsWith("#")) break;
+
+    if (!line.startsWith("|")) {
+      if (inTable) break;
+      continue;
+    }
+
+    inTable = true;
+    const firstCell = rawLine.split("|")[1]?.trim() ?? "";
+    if (/^:?-{3,}:?$/.test(firstCell)) continue;
+
+    const match = line.match(/^\|\s*`([^`]+)`\s*\|/);
+    if (!match?.[1]) continue;
+
+    const tool = match[1].trim();
+    if (!tool || seen.has(tool)) continue;
+    seen.add(tool);
+    out.push(tool);
+  }
+
+  return out.sort((a, b) => a.localeCompare(b));
+}
+
 function extractYamlFrontmatterBlock(markdown: string): string | null {
   const normalized = (markdown ?? "").replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
@@ -178,6 +219,41 @@ describe("Docs/prompt MCP tool consistency", () => {
         overview,
         "Explicit write tools (apply, implemented):",
       );
+
+      expect(docsReadTools).toEqual(readTools);
+      expect(docsWriteTools).toEqual(writeTools);
+    });
+  });
+
+  it("keeps docs/architecture/python-mcp-parity.md tool coverage in sync with tools/list", async () => {
+    await withTempDir("ailss-mcp-docs-", async (dir) => {
+      const dbPath = path.join(dir, "index.sqlite");
+
+      const readTools = await withMcpHttpServer(
+        { dbPath, enableWriteTools: false },
+        async (ctx) => {
+          const sessionId = await mcpInitialize(ctx.url, ctx.token, "client-docs");
+          return toolNamesFromList(await mcpToolsList(ctx.url, ctx.token, sessionId));
+        },
+      );
+
+      const allTools = await withMcpHttpServer({ dbPath, enableWriteTools: true }, async (ctx) => {
+        const sessionId = await mcpInitialize(ctx.url, ctx.token, "client-docs");
+        return toolNamesFromList(await mcpToolsList(ctx.url, ctx.token, sessionId));
+      });
+
+      const writeTools = diffSet(allTools, readTools).sort((a, b) => a.localeCompare(b));
+
+      const parityDocPath = path.join(
+        process.cwd(),
+        "docs",
+        "architecture",
+        "python-mcp-parity.md",
+      );
+      const parityDoc = await fs.readFile(parityDocPath, "utf8");
+
+      const docsReadTools = extractToolListFromTable(parityDoc, "## Read tool parity matrix");
+      const docsWriteTools = extractToolListFromTable(parityDoc, "## Write tool parity matrix");
 
       expect(docsReadTools).toEqual(readTools);
       expect(docsWriteTools).toEqual(writeTools);


### PR DESCRIPTION
## What

- add a Python parity boundary doc for the current MCP read/write tool surface, including current Node-only gaps and the migration gate
- add MCP docs coverage tests that keep the parity matrix aligned with the live read/write tool surface
- add Python parity contract tests for scoped retrieval, missing-context behavior, explicit write refusal, and failure-code documentation sync

## Why

- issue #182 needs an explicit parity target before any later runtime removal can be evaluated safely
- document the current Python baseline gaps instead of implying that MCP read/write parity already exists
- keep parity-critical contracts under automated verification so the migration boundary does not drift

- Fixes #182

## How

- add `docs/architecture/python-mcp-parity.md` and link it from the docs indexes
- extend `packages/mcp/test/docs.mcpToolingConsistency.test.ts` to verify that the parity matrix covers the live MCP tool surface
- add `apps/api/tests/test_parity_contract.py` and seed combined tag coverage for scoped retrieval checks
- validate with `pnpm check:ci`