### PR TITLE
feat: re-center the Obsidian plugin around the Python backend runtime

### DIFF
--- a/docs/01-overview.md
+++ b/docs/01-overview.md
@@ -110,7 +110,11 @@ Write tools are gated and not exposed by default:
 Responsibilities:
 
 - Display recommendations in a UI.
+- Center the local runtime around the Python backend for health, retrieval, agent, eval,
+  and status flows.
 - Keep the local index DB up to date (manual reindex and optional debounced auto-index).
+- Treat the MCP transport and existing indexer as transition components while the current
+  migration remains in progress.
 - Only perform vault writes when explicitly requested (for example an MCP write tool call with `apply=true`).
 - Applying changes can be implemented either via the Obsidian Vault API or via direct filesystem writes (but must remain gated and auditable).
 
@@ -127,6 +131,8 @@ Responsibilities:
   transport, and gated vault writes.
 - The Python-first backend surface now owns the local API contracts for retrieval, agent
   orchestration, evaluation, and lightweight observability.
+- Plugin startup, status, and troubleshooting flows should center on that Python backend
+  surface while the Node-owned components remain explicit transition layers.
 - The current backend contract is `GET /health`, `POST /retrieve`, `POST /agent/run`, and
   `POST /eval/run`, with plugin-managed lifecycle plus a guarded shutdown path for stale
   local processes.

--- a/packages/obsidian-plugin/README.md
+++ b/packages/obsidian-plugin/README.md
@@ -1,14 +1,19 @@
 # AILSS Obsidian Plugin (`ailss-obsidian`)
 
-This plugin manages AILSS indexing and hosts a localhost MCP service for Codex.
+This plugin keeps Obsidian as the local UX shell while centering the runtime around the
+Python backend. It also manages the transition indexer and optional localhost MCP service
+that still support the current desktop workflow.
 
 Current MVP:
 
+- Local Python backend lifecycle for health, retrieval, grounded agent runs, and evals
 - Command to reindex the vault (writes `<Vault>/.ailss/index.sqlite`)
-- Status bar items + modals for indexer/service status
-- Optional localhost MCP service for Codex (streamable HTTP; URL + token)
+- Status bar items + modals for backend/indexer/service status
+- Optional localhost MCP service for Codex during the transition period (streamable HTTP; URL + token)
 
-The plugin is **desktop-only** right now because it spawns local Node processes (indexer + MCP server/service).
+The plugin is **desktop-only** right now because it spawns local Python and Node processes.
+The Python backend is the primary local runtime; the indexer and MCP service remain
+transition components until later migration work completes.
 
 ## Setup (local dev)
 
@@ -41,16 +46,19 @@ When installed from GitHub Release, you can usually leave MCP/indexer args empty
 
 4. Configure settings inside Obsidian
 
+- **Python backend (local)**: this is the primary local runtime for health, retrieval,
+  agent runs, and evals
+    - enable the backend first if you want the plugin to start and supervise it automatically
 - **OpenAI API key**: required for indexing and MCP query embeddings
 - **Top K**: default `get_context.top_k` when the caller omits `top_k` (Codex)
 - If installed from GitHub Release:
     - keep `MCP args` and `Indexer args` empty to use bundled scripts
-- **MCP command/args**: how to run the AILSS MCP server (stdio)
+- **MCP service (Codex, localhost)**: optional transition service (`http://127.0.0.1:<port>/mcp`)
+    - enable the service, generate a token, and use “Copy config block” to paste into `~/.codex/config.toml`
+- **MCP command/args**: how to run the AILSS MCP server transition path (stdio)
     - Example for source-build install:
         - command: `node`
         - args: `/absolute/path/to/AILSS-project/packages/mcp/dist/stdio.js`
-- **MCP service (Codex, localhost)**: optional localhost service (`http://127.0.0.1:<port>/mcp`)
-    - Enable the service, generate a token, and use “Copy config block” to paste into `~/.codex/config.toml`
 - **Indexer command/args**: enables `AILSS: Reindex vault` and auto indexing
     - Example for source-build install:
         - command: `node`
@@ -62,6 +70,8 @@ When installed from GitHub Release, you can usually leave MCP/indexer args empty
 
 - `AILSS: Reindex vault`: runs the indexer to update `<Vault>/.ailss/index.sqlite`
 - `AILSS: Indexing status`: shows indexing progress + last successful indexing time
+- `AILSS: Python backend status`: shows the primary local runtime status and troubleshooting actions
 
-The plugin also adds status bar items that show indexing progress (and last success time) and the MCP service status (click for details + one-click restart).
+The plugin also adds status bar items that show the Python backend status, indexing progress
+(and last success time), and the MCP service status.
 Times shown in the UI are displayed in your system timezone (local time).

--- a/packages/obsidian-plugin/src/commands/registerCommands.ts
+++ b/packages/obsidian-plugin/src/commands/registerCommands.ts
@@ -20,6 +20,12 @@ export function registerCommands(plugin: AilssObsidianPlugin): void {
 	});
 
 	plugin.addCommand({
+		id: "python-backend-status",
+		name: "AILSS: Python backend status",
+		callback: () => plugin.openPythonStatusModal(),
+	});
+
+	plugin.addCommand({
 		id: "python-backend-retrieve",
 		name: "AILSS: Retrieve with Python backend",
 		callback: () => void plugin.retrieveWithPythonBackend(),

--- a/packages/obsidian-plugin/src/main.ts
+++ b/packages/obsidian-plugin/src/main.ts
@@ -17,6 +17,7 @@ import {
 } from "./pythonApi/client.js";
 import { PythonApiServiceController } from "./pythonApi/pythonApiServiceController.js";
 import type { AilssPythonApiServiceStatusSnapshot } from "./pythonApi/pythonApiServiceTypes.js";
+import { startConfiguredServices } from "./runtime/startConfiguredServices.js";
 import {
 	AilssObsidianSettingTab,
 	DEFAULT_SETTINGS,
@@ -27,14 +28,17 @@ import {
 	openIndexerStatusModal as openIndexerStatusModalUi,
 	openLastIndexerLogModal as openLastIndexerLogModalUi,
 	openMcpStatusModal as openMcpStatusModalUi,
+	openPythonStatusModal as openPythonStatusModalUi,
 } from "./ui/pluginModals.js";
 import { showErrorNotice, showNotice } from "./ui/pluginNotices.js";
 import { openPythonApiPromptModal, openTextViewModal } from "./ui/pythonApiCommandModals.js";
 import {
 	mountIndexerStatusBar,
 	mountMcpStatusBar,
+	mountPythonStatusBar,
 	renderIndexerStatusBar,
 	renderMcpStatusBar,
+	renderPythonStatusBar,
 } from "./ui/statusBars.js";
 import {
 	clampPort,
@@ -66,6 +70,7 @@ export type { AilssPythonApiServiceStatusSnapshot } from "./pythonApi/pythonApiS
 export default class AilssObsidianPlugin extends Plugin {
 	settings!: AilssObsidianSettings;
 
+	private pythonStatusBarEl: HTMLElement | null = null;
 	private statusBarEl: HTMLElement | null = null;
 	private mcpStatusBarEl: HTMLElement | null = null;
 
@@ -102,7 +107,8 @@ export default class AilssObsidianPlugin extends Plugin {
 			}),
 		getUrl: () => this.getPythonApiServiceUrl(),
 		onStatusChanged: () => {
-			// settings-only status for now
+			if (!this.pythonStatusBarEl) return;
+			renderPythonStatusBar(this.pythonStatusBarEl, this.getPythonApiServiceStatusSnapshot());
 		},
 	});
 
@@ -141,26 +147,31 @@ export default class AilssObsidianPlugin extends Plugin {
 		await this.ensureMcpHttpServiceShutdownToken();
 		await this.ensurePythonApiServiceShutdownToken();
 
+		this.pythonStatusBarEl = mountPythonStatusBar(this, {
+			onClick: () => this.openPythonStatusModal(),
+		});
 		this.statusBarEl = mountIndexerStatusBar(this, {
 			onClick: () => this.openIndexerStatusModal(),
 		});
 		this.mcpStatusBarEl = mountMcpStatusBar(this, {
 			onClick: () => this.openMcpStatusModal(),
 		});
+		renderPythonStatusBar(this.pythonStatusBarEl, this.getPythonApiServiceStatusSnapshot());
 		renderMcpStatusBar(this.mcpStatusBarEl, this.getMcpHttpServiceStatusSnapshot());
 
 		this.addSettingTab(new AilssObsidianSettingTab(this.app, this));
 		registerCommands(this);
 		registerAutoIndexEvents(this, this.autoIndex);
 
-		if (this.settings.mcpHttpServiceEnabled) {
-			await this.startMcpHttpService();
-		}
-		if (this.settings.pythonApiServiceEnabled) {
-			await this.startPythonApiService();
-		}
+		await startConfiguredServices({
+			pythonApiServiceEnabled: this.settings.pythonApiServiceEnabled,
+			mcpHttpServiceEnabled: this.settings.mcpHttpServiceEnabled,
+			startPythonApiService: async () => await this.startPythonApiService(),
+			startMcpHttpService: async () => await this.startMcpHttpService(),
+		});
 
 		this.indexer.emitNow();
+		renderPythonStatusBar(this.pythonStatusBarEl, this.getPythonApiServiceStatusSnapshot());
 		renderMcpStatusBar(this.mcpStatusBarEl, this.getMcpHttpServiceStatusSnapshot());
 	}
 
@@ -555,6 +566,10 @@ export default class AilssObsidianPlugin extends Plugin {
 
 	openMcpStatusModal(): void {
 		openMcpStatusModalUi(this);
+	}
+
+	openPythonStatusModal(): void {
+		openPythonStatusModalUi(this);
 	}
 
 	getLastIndexerLogSnapshot(): {

--- a/packages/obsidian-plugin/src/runtime/startConfiguredServices.ts
+++ b/packages/obsidian-plugin/src/runtime/startConfiguredServices.ts
@@ -1,0 +1,14 @@
+export async function startConfiguredServices(options: {
+	pythonApiServiceEnabled: boolean;
+	mcpHttpServiceEnabled: boolean;
+	startPythonApiService: () => Promise<void>;
+	startMcpHttpService: () => Promise<void>;
+}): Promise<void> {
+	if (options.pythonApiServiceEnabled) {
+		await options.startPythonApiService();
+	}
+
+	if (options.mcpHttpServiceEnabled) {
+		await options.startMcpHttpService();
+	}
+}

--- a/packages/obsidian-plugin/src/settingsSections/advancedSection.ts
+++ b/packages/obsidian-plugin/src/settingsSections/advancedSection.ts
@@ -12,45 +12,15 @@ export function renderAdvancedSection(
 	containerEl.createEl("h3", { text: "Advanced (spawn overrides)" });
 	const details = containerEl.createEl("details");
 	details.createEl("summary", {
-		text: "Show advanced settings (server/indexer command + args)",
+		text: "Show advanced settings (backend/service/indexer command + args)",
 	});
 	const advancedContainer = details.createDiv();
-	advancedContainer.createEl("h4", { text: "MCP server (local)" });
-
-	new Setting(advancedContainer)
-		.setName("Command")
-		.setDesc(
-			"How to launch the AILSS MCP server (stdio). If you see 'spawn node ENOENT', set this to your absolute Node path (run 'which node' on macOS/Linux, or 'where node' on Windows).",
-		)
-		.addText((text) => {
-			text.setPlaceholder("node");
-			text.setValue(plugin.settings.mcpCommand);
-			text.onChange(async (value) => {
-				await updateSetting("mcpCommand", value.trim() || DEFAULT_SETTINGS.mcpCommand);
-			});
-		});
-
-	new Setting(advancedContainer)
-		.setName("Arguments (one per line)")
-		.setDesc(
-			[
-				"Optional script path override for the MCP server.",
-				"Leave empty to use the bundled service (release zip) when available.",
-				'Example: "/absolute/path/to/AILSS-project/packages/mcp/dist/stdio.js" (for command "node").',
-			].join("\n"),
-		)
-		.addTextArea((text) => {
-			text.setValue(plugin.settings.mcpArgs.join("\n"));
-			text.onChange(async (value) => {
-				await updateSetting("mcpArgs", parseArgs(value));
-			});
-		});
 
 	advancedContainer.createEl("h4", { text: "Python backend (local)" });
 	new Setting(advancedContainer)
 		.setName("Command")
 		.setDesc(
-			"How to launch the local Python backend. If you see 'spawn uv ENOENT', set this to your absolute uv path.",
+			"How to launch the primary local Python backend. If you see 'spawn uv ENOENT', set this to your absolute uv path.",
 		)
 		.addText((text) => {
 			text.setPlaceholder("uv");
@@ -76,6 +46,37 @@ export function renderAdvancedSection(
 			text.setValue(plugin.settings.pythonApiArgs.join("\n"));
 			text.onChange(async (value) => {
 				await updateSetting("pythonApiArgs", parseArgs(value));
+			});
+		});
+
+	advancedContainer.createEl("h4", { text: "MCP service (transition layer)" });
+
+	new Setting(advancedContainer)
+		.setName("Command")
+		.setDesc(
+			"How to launch the optional AILSS MCP service transition path. If you see 'spawn node ENOENT', set this to your absolute Node path (run 'which node' on macOS/Linux, or 'where node' on Windows).",
+		)
+		.addText((text) => {
+			text.setPlaceholder("node");
+			text.setValue(plugin.settings.mcpCommand);
+			text.onChange(async (value) => {
+				await updateSetting("mcpCommand", value.trim() || DEFAULT_SETTINGS.mcpCommand);
+			});
+		});
+
+	new Setting(advancedContainer)
+		.setName("Arguments (one per line)")
+		.setDesc(
+			[
+				"Optional script path override for the MCP service transition path.",
+				"Leave empty to use the bundled service (release zip) when available.",
+				'Example: "/absolute/path/to/AILSS-project/packages/mcp/dist/stdio.js" (for command "node").',
+			].join("\n"),
+		)
+		.addTextArea((text) => {
+			text.setValue(plugin.settings.mcpArgs.join("\n"));
+			text.onChange(async (value) => {
+				await updateSetting("mcpArgs", parseArgs(value));
 			});
 		});
 

--- a/packages/obsidian-plugin/src/settingsSections/mcpServiceSection.ts
+++ b/packages/obsidian-plugin/src/settingsSections/mcpServiceSection.ts
@@ -14,7 +14,7 @@ export function renderMcpServiceSection(
 	new Setting(containerEl)
 		.setName("Enable service")
 		.setDesc(
-			`${plugin.getMcpHttpServiceStatusLine()}\n\nRuns a localhost MCP server for Codex to connect to (URL + token).`,
+			`${plugin.getMcpHttpServiceStatusLine()}\n\nRuns an optional localhost transition service for Codex while the plugin remains centered on the Python backend runtime.`,
 		)
 		.addToggle((toggle) => {
 			toggle.setValue(plugin.settings.mcpHttpServiceEnabled);
@@ -46,7 +46,9 @@ export function renderMcpServiceSection(
 
 	new Setting(containerEl)
 		.setName("Enable write tools over MCP")
-		.setDesc("Allows Codex to call write tools like edit_note (still requires apply=true).")
+		.setDesc(
+			"Allows the optional MCP transition service to expose write tools like edit_note (still requires apply=true).",
+		)
 		.addToggle((toggle) => {
 			toggle.setValue(plugin.settings.mcpHttpServiceEnableWriteTools);
 			toggle.onChange(async (value) => {
@@ -74,7 +76,7 @@ export function renderMcpServiceSection(
 	new Setting(containerEl)
 		.setName("Codex config")
 		.setDesc(
-			"Copies a ready-to-paste ~/.codex/config.toml block for connecting to this service.",
+			"Copies a ready-to-paste ~/.codex/config.toml block for the optional localhost MCP transition service.",
 		)
 		.addButton((button) => {
 			button.setButtonText("Copy config block");

--- a/packages/obsidian-plugin/src/settingsSections/pythonApiSection.ts
+++ b/packages/obsidian-plugin/src/settingsSections/pythonApiSection.ts
@@ -14,7 +14,7 @@ export function renderPythonApiSection(
 	new Setting(containerEl)
 		.setName("Enable backend")
 		.setDesc(
-			`${plugin.getPythonApiServiceStatusLine()}\n\nRuns the local FastAPI backend that owns retrieval, agent workflow, and eval endpoints.`,
+			`${plugin.getPythonApiServiceStatusLine()}\n\nRuns the primary local FastAPI runtime for health, retrieval, agent workflow, and eval endpoints.`,
 		)
 		.addToggle((toggle) => {
 			toggle.setValue(plugin.settings.pythonApiServiceEnabled);
@@ -46,7 +46,11 @@ export function renderPythonApiSection(
 
 	new Setting(containerEl)
 		.setName("Controls")
-		.setDesc("Start or restart the local Python backend process from the plugin.")
+		.setDesc("Open status, run health checks, or restart the primary local backend.")
+		.addButton((button) => {
+			button.setButtonText("Open status");
+			button.onClick(() => plugin.openPythonStatusModal());
+		})
 		.addButton((button) => {
 			button.setButtonText("Restart backend");
 			button.onClick(() => void plugin.restartPythonApiService());

--- a/packages/obsidian-plugin/src/ui/pluginModals.ts
+++ b/packages/obsidian-plugin/src/ui/pluginModals.ts
@@ -3,6 +3,7 @@ import type AilssObsidianPlugin from "../main.js";
 import { AilssIndexerLogModal } from "./indexerLogModal.js";
 import { AilssIndexerStatusModal } from "./indexerStatusModal.js";
 import { AilssMcpStatusModal } from "./mcpStatusModal.js";
+import { AilssPythonStatusModal } from "./pythonStatusModal.js";
 
 export function openLastIndexerLogModal(plugin: AilssObsidianPlugin): void {
 	new AilssIndexerLogModal(plugin.app, plugin).open();
@@ -14,4 +15,8 @@ export function openIndexerStatusModal(plugin: AilssObsidianPlugin): void {
 
 export function openMcpStatusModal(plugin: AilssObsidianPlugin): void {
 	new AilssMcpStatusModal(plugin.app, plugin).open();
+}
+
+export function openPythonStatusModal(plugin: AilssObsidianPlugin): void {
+	new AilssPythonStatusModal(plugin.app, plugin).open();
 }

--- a/packages/obsidian-plugin/src/ui/pythonStatusModal.ts
+++ b/packages/obsidian-plugin/src/ui/pythonStatusModal.ts
@@ -1,0 +1,209 @@
+import { ButtonComponent, Modal, Notice, Setting } from "obsidian";
+
+import type AilssObsidianPlugin from "../main.js";
+import type { AilssPythonApiServiceStatusSnapshot } from "../pythonApi/pythonApiServiceTypes.js";
+import { formatAilssTimestampForUi } from "../utils/dateTime.js";
+
+export class AilssPythonStatusModal extends Modal {
+	private statusTextEl: HTMLElement | null = null;
+	private metaTextEl: HTMLElement | null = null;
+	private errorTextEl: HTMLElement | null = null;
+	private copyErrorButton: ButtonComponent | null = null;
+	private healthButton: ButtonComponent | null = null;
+	private restartButton: ButtonComponent | null = null;
+	private checkingHealth = false;
+	private restarting = false;
+
+	constructor(
+		app: AilssObsidianPlugin["app"],
+		private readonly plugin: AilssObsidianPlugin,
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("ailss-obsidian");
+
+		contentEl.createEl("h2", { text: "AILSS Python backend status" });
+
+		this.statusTextEl = contentEl.createDiv({ cls: "ailss-status" });
+		this.metaTextEl = contentEl.createDiv({ cls: "ailss-status" });
+		this.errorTextEl = contentEl.createDiv({ cls: "ailss-modal-message" });
+
+		new Setting(contentEl)
+			.setName("Actions")
+			.addButton((button) => {
+				this.copyErrorButton = button;
+				button.setButtonText("Copy error message");
+				button.onClick(
+					() =>
+						void this.copyToClipboard(
+							this.plugin.getPythonApiServiceStatusSnapshot().lastErrorMessage ?? "",
+							{
+								emptyNotice: "No error message to copy.",
+								successNotice: "Copied error message to clipboard.",
+							},
+						),
+				);
+			})
+			.addButton((button) => {
+				this.healthButton = button;
+				button.setButtonText("Check health");
+				button.onClick(() => void this.checkHealth());
+			})
+			.addButton((button) => {
+				this.restartButton = button;
+				button.setButtonText("Restart backend");
+				button.setCta();
+				button.onClick(() => void this.restartBackend());
+			});
+
+		this.refresh();
+	}
+
+	onClose(): void {
+		this.statusTextEl = null;
+		this.metaTextEl = null;
+		this.errorTextEl = null;
+		this.copyErrorButton = null;
+		this.healthButton = null;
+		this.restartButton = null;
+		this.contentEl.empty();
+	}
+
+	private refresh(): void {
+		const snapshot = this.plugin.getPythonApiServiceStatusSnapshot();
+		this.render(snapshot);
+	}
+
+	private render(snapshot: AilssPythonApiServiceStatusSnapshot): void {
+		if (this.statusTextEl) {
+			this.statusTextEl.setText(
+				statusLine(snapshot, {
+					checkingHealth: this.checkingHealth,
+					restarting: this.restarting,
+				}),
+			);
+		}
+
+		if (this.metaTextEl) {
+			const startedAt = formatAilssTimestampForUi(snapshot.startedAt);
+			const lastStoppedAt = formatAilssTimestampForUi(snapshot.lastStoppedAt);
+			const metaParts = [
+				"Runtime: Primary local backend",
+				`Service: ${snapshot.enabled ? "Enabled" : "Disabled"}`,
+				`URL: ${snapshot.url}`,
+				startedAt ? `Started: ${startedAt}` : "",
+				lastStoppedAt ? `Last stopped: ${lastStoppedAt}` : "",
+				snapshot.lastExitCode === null ? "" : `Last exit: ${snapshot.lastExitCode}`,
+				!snapshot.enabled ? "Enable the backend in settings to start or restart it." : "",
+			];
+			this.metaTextEl.setText(metaParts.filter(Boolean).join("\n"));
+		}
+
+		if (this.errorTextEl) {
+			const message = snapshot.lastErrorMessage?.trim() ?? "";
+			if (message) {
+				this.errorTextEl.style.display = "";
+				this.errorTextEl.setText(message);
+			} else {
+				this.errorTextEl.style.display = "none";
+				this.errorTextEl.setText("");
+			}
+		}
+
+		if (this.copyErrorButton) {
+			this.copyErrorButton.setDisabled(
+				this.checkingHealth || this.restarting || !snapshot.lastErrorMessage?.trim(),
+			);
+		}
+
+		if (this.healthButton) {
+			this.healthButton.setDisabled(
+				this.checkingHealth || this.restarting || !snapshot.enabled,
+			);
+		}
+
+		if (this.restartButton) {
+			this.restartButton.setDisabled(
+				this.checkingHealth || this.restarting || !snapshot.enabled,
+			);
+		}
+	}
+
+	private async copyToClipboard(
+		text: string,
+		notices: { emptyNotice: string; successNotice: string },
+	): Promise<void> {
+		if (!text.trim()) {
+			new Notice(notices.emptyNotice);
+			return;
+		}
+
+		try {
+			// Clipboard API availability
+			const clipboard = (
+				navigator as unknown as { clipboard?: { writeText?: (v: string) => Promise<void> } }
+			).clipboard;
+			if (!clipboard?.writeText) {
+				new Notice("Clipboard not available.");
+				return;
+			}
+
+			await clipboard.writeText(text);
+			new Notice(notices.successNotice);
+		} catch {
+			new Notice("Copy failed.");
+		}
+	}
+
+	private async checkHealth(): Promise<void> {
+		if (this.checkingHealth || this.restarting) return;
+
+		this.checkingHealth = true;
+		this.refresh();
+		try {
+			await this.plugin.checkPythonApiHealth();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			new Notice(`Health check failed: ${message}`);
+		} finally {
+			this.checkingHealth = false;
+			this.refresh();
+		}
+	}
+
+	private async restartBackend(): Promise<void> {
+		if (this.checkingHealth || this.restarting) return;
+
+		this.restarting = true;
+		this.refresh();
+		try {
+			await this.plugin.restartPythonApiService();
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			new Notice(`Restart failed: ${message}`);
+		} finally {
+			this.restarting = false;
+			this.refresh();
+		}
+	}
+}
+
+function statusLine(
+	snapshot: AilssPythonApiServiceStatusSnapshot,
+	options: { checkingHealth: boolean; restarting: boolean },
+): string {
+	if (options.restarting) return "Status: Restarting…";
+	if (options.checkingHealth) return "Status: Checking health…";
+	if (!snapshot.enabled) return "Status: Off";
+	if (snapshot.running) return "Status: Running";
+	if (snapshot.lastErrorMessage) return "Status: Error";
+	if (snapshot.lastStoppedAt) {
+		const lastStoppedAt = formatAilssTimestampForUi(snapshot.lastStoppedAt);
+		return `Status: Stopped (last: ${lastStoppedAt ?? snapshot.lastStoppedAt})`;
+	}
+	return "Status: Stopped";
+}

--- a/packages/obsidian-plugin/src/ui/statusBars.ts
+++ b/packages/obsidian-plugin/src/ui/statusBars.ts
@@ -2,6 +2,7 @@ import { type Plugin } from "obsidian";
 
 import type { AilssIndexerStatusSnapshot } from "../indexer/indexerRunner.js";
 import type { AilssMcpHttpServiceStatusSnapshot } from "../mcp/mcpHttpServiceTypes.js";
+import type { AilssPythonApiServiceStatusSnapshot } from "../pythonApi/pythonApiServiceTypes.js";
 import { formatAilssTimestampForUi } from "../utils/dateTime.js";
 
 export function mountIndexerStatusBar(
@@ -19,6 +20,18 @@ export function mountIndexerStatusBar(
 export function mountMcpStatusBar(plugin: Plugin, options: { onClick: () => void }): HTMLElement {
 	const el = plugin.addStatusBarItem();
 	el.addClass("ailss-obsidian-mcp-statusbar");
+	el.setAttribute("role", "button");
+	el.addEventListener("click", options.onClick);
+	plugin.register(() => el.remove());
+	return el;
+}
+
+export function mountPythonStatusBar(
+	plugin: Plugin,
+	options: { onClick: () => void },
+): HTMLElement {
+	const el = plugin.addStatusBarItem();
+	el.addClass("ailss-obsidian-python-statusbar");
 	el.setAttribute("role", "button");
 	el.addEventListener("click", options.onClick);
 	plugin.register(() => el.remove());
@@ -58,6 +71,50 @@ export function renderMcpStatusBar(
 		"title",
 		[
 			"AILSS MCP service stopped",
+			lastStoppedAt ? `Last stopped: ${lastStoppedAt}` : "",
+			snapshot.url,
+		]
+			.filter(Boolean)
+			.join("\n"),
+	);
+}
+
+export function renderPythonStatusBar(
+	el: HTMLElement,
+	snapshot: AilssPythonApiServiceStatusSnapshot,
+): void {
+	el.removeClass("is-running");
+	el.removeClass("is-error");
+
+	if (!snapshot.enabled) {
+		el.textContent = "AILSS: backend off";
+		el.setAttribute("title", "AILSS Python backend is disabled.");
+		return;
+	}
+
+	if (snapshot.running) {
+		el.textContent = "AILSS: backend running";
+		el.addClass("is-running");
+		el.setAttribute("title", ["AILSS Python backend running", snapshot.url].join("\n"));
+		return;
+	}
+
+	if (snapshot.lastErrorMessage) {
+		el.textContent = "AILSS: backend error";
+		el.addClass("is-error");
+		el.setAttribute(
+			"title",
+			["AILSS Python backend error", snapshot.lastErrorMessage].join("\n"),
+		);
+		return;
+	}
+
+	el.textContent = "AILSS: backend stopped";
+	const lastStoppedAt = formatAilssTimestampForUi(snapshot.lastStoppedAt);
+	el.setAttribute(
+		"title",
+		[
+			"AILSS Python backend stopped",
 			lastStoppedAt ? `Last stopped: ${lastStoppedAt}` : "",
 			snapshot.url,
 		]

--- a/packages/obsidian-plugin/test/runtime/startConfiguredServices.test.ts
+++ b/packages/obsidian-plugin/test/runtime/startConfiguredServices.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { startConfiguredServices } from "../../src/runtime/startConfiguredServices.js";
+
+describe("startConfiguredServices", () => {
+	it("starts the Python backend before the MCP transition service", async () => {
+		const calls: string[] = [];
+
+		await startConfiguredServices({
+			pythonApiServiceEnabled: true,
+			mcpHttpServiceEnabled: true,
+			startPythonApiService: vi.fn(async () => {
+				calls.push("python");
+			}),
+			startMcpHttpService: vi.fn(async () => {
+				calls.push("mcp");
+			}),
+		});
+
+		expect(calls).toEqual(["python", "mcp"]);
+	});
+
+	it("skips disabled services", async () => {
+		const startPythonApiService = vi.fn(async () => {});
+		const startMcpHttpService = vi.fn(async () => {});
+
+		await startConfiguredServices({
+			pythonApiServiceEnabled: false,
+			mcpHttpServiceEnabled: true,
+			startPythonApiService,
+			startMcpHttpService,
+		});
+
+		expect(startPythonApiService).not.toHaveBeenCalled();
+		expect(startMcpHttpService).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/obsidian-plugin/test/ui/statusBars.test.ts
+++ b/packages/obsidian-plugin/test/ui/statusBars.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { renderPythonStatusBar } from "../../src/ui/statusBars.js";
+
+type MockElement = {
+	textContent: string;
+	attributes: Map<string, string>;
+	classes: Set<string>;
+	setAttribute: (name: string, value: string) => void;
+	addClass: (name: string) => void;
+	removeClass: (name: string) => void;
+};
+
+function createElement(): MockElement {
+	return {
+		textContent: "",
+		attributes: new Map(),
+		classes: new Set(),
+		setAttribute(name: string, value: string) {
+			this.attributes.set(name, value);
+		},
+		addClass(name: string) {
+			this.classes.add(name);
+		},
+		removeClass(name: string) {
+			this.classes.delete(name);
+		},
+	};
+}
+
+describe("renderPythonStatusBar", () => {
+	it("renders the running backend as the primary runtime", () => {
+		const el = createElement();
+
+		renderPythonStatusBar(el as unknown as HTMLElement, {
+			enabled: true,
+			url: "http://127.0.0.1:8787",
+			running: true,
+			startedAt: "2026-03-19T00:00:00.000Z",
+			lastExitCode: null,
+			lastStoppedAt: null,
+			lastErrorMessage: null,
+		});
+
+		expect(el.textContent).toBe("AILSS: backend running");
+		expect(el.classes.has("is-running")).toBe(true);
+		expect(el.attributes.get("title")).toContain("AILSS Python backend running");
+	});
+
+	it("renders backend errors ahead of stopped state", () => {
+		const el = createElement();
+
+		renderPythonStatusBar(el as unknown as HTMLElement, {
+			enabled: true,
+			url: "http://127.0.0.1:8787",
+			running: false,
+			startedAt: null,
+			lastExitCode: 1,
+			lastStoppedAt: "2026-03-19T00:00:00.000Z",
+			lastErrorMessage: "Readiness check failed",
+		});
+
+		expect(el.textContent).toBe("AILSS: backend error");
+		expect(el.classes.has("is-error")).toBe(true);
+		expect(el.attributes.get("title")).toContain("Readiness check failed");
+	});
+});


### PR DESCRIPTION
## What
- Re-center the plugin runtime UI around the Python backend with a primary backend status bar/modal and Python-first startup order
- Reword settings and commands so MCP is treated as an optional transition service
- Update plugin/runtime docs to describe the Python-centered local runtime model

## Why
- Issue #180 tracks the plugin transition from split runtime ownership to a Python-centered local backend model
- The plugin already launches the Python backend, but startup order and status/troubleshooting UX still emphasized transition-first assumptions

- Fixes #180

## How
- Add a Python backend status bar/modal, a Python backend status command, and a small startup helper that boots Python before MCP when both are enabled
- Keep MCP and indexer explicit as transition components in settings copy and README/overview docs
- Add focused tests for Python-first startup order and backend status bar rendering, then verify with `pnpm check:ci`